### PR TITLE
change camera handling in update_gizmos function

### DIFF
--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -177,9 +177,25 @@ fn update_gizmos(
 
     let scale_factor = window.scale_factor();
 
-    let Ok((camera, camera_transform)) = q_gizmo_camera.get_single() else {
-        bevy::log::warn!("Only one camera with a GizmoCamera component is supported.");
-        return;
+    let (camera, camera_transform) = {
+        let mut active_camera = None;
+
+        for camera in q_gizmo_camera.iter() {
+            if !camera.0.is_active {
+                continue;
+            }
+            if active_camera.is_some() {
+                // multiple active cameras found, warn and skip
+                bevy::log::warn!("Only one camera with a GizmoCamera component is supported.");
+                return;
+            }
+            active_camera = Some(camera);
+        }
+
+        match active_camera {
+            Some(camera) => camera,
+            None => return, // no active cameras in the scene
+        }
     };
 
     let Some(viewport) = camera.logical_viewport_rect() else {


### PR DESCRIPTION
Current plugin code requires user to have exactly 1 gizmo camera in the scene at all times. Otherwise, you get a nasty warning every frame.

This PR makes it so:
 - there're no warnings if gizmo cameras don't exist
 - multiple gizmo cameras are fine as long as only one is active

----

Use-case 1:

Lets say I have an editor mode in my application that's not always on (with a separate camera with different perspective perhaps). But most of the time, that camera will not exist, and it's only inserted when user enters a state.

I get a warning because there are no gizmo cameras.

Use-case 2:

Lets say I have multiple gizmo cameras and intend to toggle between them with a keyboard shortcut. But only one is active at any given time. Currently, that's not supported, but there's no reason why it shouldn't be.

After this commit, it's going to only pick `is_active` gizmo camera (and warn if there're multiples).