### PR TITLE
Add more granular gizmo mode configuration & hotkeys 

### DIFF
--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -96,7 +96,7 @@ pub struct GizmoOptions {
 impl Default for GizmoOptions {
     fn default() -> Self {
         Self {
-            gizmo_modes: EnumSet::only(GizmoMode::Rotate),
+            gizmo_modes: GizmoMode::all(),
             gizmo_orientation: GizmoOrientation::default(),
             pivot_point: TransformPivotPoint::default(),
             visuals: Default::default(),

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -120,7 +120,7 @@ impl Default for GizmoOptions {
             snap_scale: DEFAULT_SNAP_SCALE,
             group_targets: true,
             mode_override: None,
-            hotkeys: Some(GizmoHotkeys::default()),
+            hotkeys: None,
             viewport_rect: None,
         }
     }
@@ -347,8 +347,8 @@ fn handle_hotkeys(
     if (hotkeys.mouse_click_deactivates
         && mouse_input.any_just_pressed([MouseButton::Left, MouseButton::Right]))
         || hotkeys
-            .deactivate_gizmo
-            .is_some_and(|key| keyboard_input.just_pressed(key))
+        .deactivate_gizmo
+        .is_some_and(|key| keyboard_input.just_pressed(key))
     {
         *mode_override = None;
     }

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -332,7 +332,7 @@ fn handle_hotkeys(
         GizmoMode::all_from_axes(*axes)
             .iter()
             .find(|mode| mode.kind() == kind)
-            .or_else(|| {
+            .or({
                 // If nothing matches, choose the default mode.
                 Some(match kind {
                     GizmoModeKind::Rotate => GizmoMode::RotateView,
@@ -347,8 +347,8 @@ fn handle_hotkeys(
     if (hotkeys.mouse_click_deactivates
         && mouse_input.any_just_pressed([MouseButton::Left, MouseButton::Right]))
         || hotkeys
-        .deactivate_gizmo
-        .is_some_and(|key| keyboard_input.just_pressed(key))
+            .deactivate_gizmo
+            .is_some_and(|key| keyboard_input.just_pressed(key))
     {
         *mode_override = None;
     }

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -172,6 +172,7 @@ struct GizmoStorage {
 fn handle_hotkeys(
     mut gizmo_options: ResMut<GizmoOptions>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
+    mouse_input: Res<ButtonInput<MouseButton>>,
     mut axes: Local<EnumSet<GizmoDirection>>,
 ) {
     // Snapping is enabled when CTRL is pressed.
@@ -273,6 +274,12 @@ fn handle_hotkeys(
                 })
             })
     });
+
+    if mouse_input.any_just_pressed([MouseButton::Left, MouseButton::Right])
+        || keyboard_input.just_pressed(KeyCode::Escape)
+    {
+        *mode_override = None;
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -121,6 +121,7 @@ impl Default for GizmoOptions {
             group_targets: true,
             mode_override: None,
             hotkeys: Some(GizmoHotkeys::default()),
+            viewport_rect: None,
         }
     }
 }
@@ -166,7 +167,6 @@ impl Default for GizmoHotkeys {
             toggle_z: Some(KeyCode::KeyZ),
             deactivate_gizmo: Some(KeyCode::Escape),
             mouse_click_deactivates: true,
-            viewport_rect: None,
         }
     }
 }

--- a/crates/transform-gizmo-egui/src/lib.rs
+++ b/crates/transform-gizmo-egui/src/lib.rs
@@ -19,7 +19,7 @@
 //! gizmo.update_config(GizmoConfig {
 //!     view_matrix: view_matrix.into(),
 //!     projection_matrix: projection_matrix.into(),
-//!     modes: enum_set!(GizmoMode::Rotate | GizmoMode::Translate | GizmoMode::Scale),
+//!     modes: GizmoMode::all(),
 //!     orientation: GizmoOrientation::Local,
 //!     ..Default::default()
 //! });

--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -231,36 +231,58 @@ impl PreparedGizmoConfig {
 /// Operation mode of a gizmo.
 #[derive(Debug, EnumSetType, Hash)]
 pub enum GizmoMode {
+    /// Rotate around the X axis
     RotateX,
+    /// Rotate around the Y axis
     RotateY,
+    /// Rotate around the Z axis
     RotateZ,
+    /// Rotate around the view forward axis
     RotateView,
+    /// Translate along the X axis
     TranslateX,
+    /// Translate along the Y axis
     TranslateY,
+    /// Translate along the Z axis
     TranslateZ,
+    /// Translate along the XY plane
     TranslateXY,
+    /// Translate along the XZ plane
     TranslateXZ,
+    /// Translate along the YZ plane
     TranslateYZ,
+    /// Translate along the view forward axis
     TranslateView,
+    /// Scale along the X axis
     ScaleX,
+    /// Scale along the Y axis
     ScaleY,
+    /// Scale along the Z axis
     ScaleZ,
+    /// Scale along the XY plane
     ScaleXY,
+    /// Scale along the XZ plane
     ScaleXZ,
+    /// Scale along the YZ plane
     ScaleYZ,
+    /// Scale uniformly in all directions
     ScaleUniform,
+    /// Rotate using an arcball (trackball)
     Arcball,
 }
 
 impl GizmoMode {
+    /// All modes
     pub fn all() -> EnumSet<GizmoMode> {
         EnumSet::all()
     }
 
+    /// All rotation modes
     pub const fn all_rotate() -> EnumSet<GizmoMode> {
         enum_set!(Self::RotateX | Self::RotateY | Self::RotateZ | Self::RotateView)
     }
 
+    /// All translation modes
     pub const fn all_translate() -> EnumSet<GizmoMode> {
         enum_set!(
             Self::TranslateX
@@ -273,6 +295,7 @@ impl GizmoMode {
         )
     }
 
+    /// All scaling modes
     pub const fn all_scale() -> EnumSet<GizmoMode> {
         enum_set!(
             Self::ScaleX
@@ -285,14 +308,17 @@ impl GizmoMode {
         )
     }
 
+    /// Is this mode for rotation
     pub fn is_rotate(&self) -> bool {
         Self::all_rotate().contains(*self)
     }
 
+    /// Is this mode for translation
     pub fn is_translate(&self) -> bool {
         Self::all_translate().contains(*self)
     }
 
+    /// Is this mode for scaling
     pub fn is_scale(&self) -> bool {
         Self::all_scale().contains(*self)
     }

--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -54,7 +54,7 @@ impl Default for GizmoConfig {
             view_matrix: DMat4::IDENTITY.into(),
             projection_matrix: DMat4::IDENTITY.into(),
             viewport: Rect::NOTHING,
-            modes: enum_set!(GizmoMode::Rotate),
+            modes: GizmoMode::all(),
             orientation: GizmoOrientation::default(),
             pivot_point: TransformPivotPoint::default(),
             snapping: false,
@@ -90,7 +90,7 @@ impl GizmoConfig {
 
     /// Transform orientation of the gizmo
     pub(crate) fn orientation(&self) -> GizmoOrientation {
-        if self.modes.contains(GizmoMode::Scale) {
+        if !self.modes.is_disjoint(GizmoMode::all_scale()) {
             // Scaling currently only works in local orientation,
             // so the configured orientation is ignored.
             GizmoOrientation::Local
@@ -229,11 +229,73 @@ impl PreparedGizmoConfig {
 }
 
 /// Operation mode of a gizmo.
-#[derive(Debug, EnumSetType)]
+#[derive(Debug, EnumSetType, Hash)]
 pub enum GizmoMode {
-    Rotate,
-    Translate,
-    Scale,
+    RotateX,
+    RotateY,
+    RotateZ,
+    RotateView,
+    TranslateX,
+    TranslateY,
+    TranslateZ,
+    TranslateXY,
+    TranslateXZ,
+    TranslateYZ,
+    TranslateView,
+    ScaleX,
+    ScaleY,
+    ScaleZ,
+    ScaleXY,
+    ScaleXZ,
+    ScaleYZ,
+    ScaleUniform,
+    Arcball,
+}
+
+impl GizmoMode {
+    pub fn all() -> EnumSet<GizmoMode> {
+        EnumSet::all()
+    }
+
+    pub const fn all_rotate() -> EnumSet<GizmoMode> {
+        enum_set!(Self::RotateX | Self::RotateY | Self::RotateZ | Self::RotateView)
+    }
+
+    pub const fn all_translate() -> EnumSet<GizmoMode> {
+        enum_set!(
+            Self::TranslateX
+                | Self::TranslateY
+                | Self::TranslateZ
+                | Self::TranslateXY
+                | Self::TranslateXZ
+                | Self::TranslateYZ
+                | Self::TranslateView
+        )
+    }
+
+    pub const fn all_scale() -> EnumSet<GizmoMode> {
+        enum_set!(
+            Self::ScaleX
+                | Self::ScaleY
+                | Self::ScaleZ
+                | Self::ScaleXY
+                | Self::ScaleXZ
+                | Self::ScaleYZ
+                | Self::ScaleUniform
+        )
+    }
+
+    pub fn is_rotate(&self) -> bool {
+        Self::all_rotate().contains(*self)
+    }
+
+    pub fn is_translate(&self) -> bool {
+        Self::all_translate().contains(*self)
+    }
+
+    pub fn is_scale(&self) -> bool {
+        Self::all_scale().contains(*self)
+    }
 }
 
 /// The point in space around which all rotations are centered.

--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -109,7 +109,7 @@ impl GizmoConfig {
     }
 
     /// Whether the modes have changed, compared to given other config
-    pub(crate) fn modes_changed(&self, other: &GizmoConfig) -> bool {
+    pub(crate) fn modes_changed(&self, other: &Self) -> bool {
         (self.modes != other.modes && self.mode_override.is_none())
             || (self.mode_override != other.mode_override)
     }
@@ -288,17 +288,17 @@ pub enum GizmoMode {
 
 impl GizmoMode {
     /// All modes
-    pub fn all() -> EnumSet<GizmoMode> {
+    pub fn all() -> EnumSet<Self> {
         EnumSet::all()
     }
 
     /// All rotation modes
-    pub const fn all_rotate() -> EnumSet<GizmoMode> {
+    pub const fn all_rotate() -> EnumSet<Self> {
         enum_set!(Self::RotateX | Self::RotateY | Self::RotateZ | Self::RotateView)
     }
 
     /// All translation modes
-    pub const fn all_translate() -> EnumSet<GizmoMode> {
+    pub const fn all_translate() -> EnumSet<Self> {
         enum_set!(
             Self::TranslateX
                 | Self::TranslateY
@@ -311,7 +311,7 @@ impl GizmoMode {
     }
 
     /// All scaling modes
-    pub const fn all_scale() -> EnumSet<GizmoMode> {
+    pub const fn all_scale() -> EnumSet<Self> {
         enum_set!(
             Self::ScaleX
                 | Self::ScaleY
@@ -341,36 +341,36 @@ impl GizmoMode {
     /// Axes this mode acts on
     pub fn axes(&self) -> EnumSet<GizmoDirection> {
         match self {
-            GizmoMode::RotateX | GizmoMode::TranslateX | GizmoMode::ScaleX => {
+            Self::RotateX | Self::TranslateX | Self::ScaleX => {
                 enum_set!(GizmoDirection::X)
             }
-            GizmoMode::RotateY | GizmoMode::TranslateY | GizmoMode::ScaleY => {
+            Self::RotateY | Self::TranslateY | Self::ScaleY => {
                 enum_set!(GizmoDirection::Y)
             }
-            GizmoMode::RotateZ | GizmoMode::TranslateZ | GizmoMode::ScaleZ => {
+            Self::RotateZ | Self::TranslateZ | Self::ScaleZ => {
                 enum_set!(GizmoDirection::Z)
             }
-            GizmoMode::RotateView | GizmoMode::TranslateView => {
+            Self::RotateView | Self::TranslateView => {
                 enum_set!(GizmoDirection::View)
             }
-            GizmoMode::ScaleUniform | GizmoMode::Arcball => {
+            Self::ScaleUniform | Self::Arcball => {
                 enum_set!(GizmoDirection::X | GizmoDirection::Y | GizmoDirection::Z)
             }
-            GizmoMode::TranslateXY | GizmoMode::ScaleXY => {
+            Self::TranslateXY | Self::ScaleXY => {
                 enum_set!(GizmoDirection::X | GizmoDirection::Y)
             }
-            GizmoMode::TranslateXZ | GizmoMode::ScaleXZ => {
+            Self::TranslateXZ | Self::ScaleXZ => {
                 enum_set!(GizmoDirection::X | GizmoDirection::Z)
             }
-            GizmoMode::TranslateYZ | GizmoMode::ScaleYZ => {
+            Self::TranslateYZ | Self::ScaleYZ => {
                 enum_set!(GizmoDirection::Y | GizmoDirection::Z)
             }
         }
     }
 
     /// Returns the modes that match to given axes exactly
-    pub fn all_from_axes(axes: EnumSet<GizmoDirection>) -> EnumSet<GizmoMode> {
-        EnumSet::<GizmoMode>::all()
+    pub fn all_from_axes(axes: EnumSet<GizmoDirection>) -> EnumSet<Self> {
+        EnumSet::<Self>::all()
             .iter()
             .filter(|mode| mode.axes() == axes)
             .collect()
@@ -378,30 +378,30 @@ impl GizmoMode {
 
     pub fn kind(&self) -> GizmoModeKind {
         match self {
-            GizmoMode::RotateX
-            | GizmoMode::RotateY
-            | GizmoMode::RotateZ
-            | GizmoMode::RotateView => GizmoModeKind::Rotate,
-            GizmoMode::TranslateX
-            | GizmoMode::TranslateY
-            | GizmoMode::TranslateZ
-            | GizmoMode::TranslateXY
-            | GizmoMode::TranslateXZ
-            | GizmoMode::TranslateYZ
-            | GizmoMode::TranslateView => GizmoModeKind::Translate,
-            GizmoMode::ScaleX
-            | GizmoMode::ScaleY
-            | GizmoMode::ScaleZ
-            | GizmoMode::ScaleXY
-            | GizmoMode::ScaleXZ
-            | GizmoMode::ScaleYZ
-            | GizmoMode::ScaleUniform => GizmoModeKind::Scale,
-            GizmoMode::Arcball => GizmoModeKind::Arcball,
+            Self::RotateX
+            | Self::RotateY
+            | Self::RotateZ
+            | Self::RotateView => GizmoModeKind::Rotate,
+            Self::TranslateX
+            | Self::TranslateY
+            | Self::TranslateZ
+            | Self::TranslateXY
+            | Self::TranslateXZ
+            | Self::TranslateYZ
+            | Self::TranslateView => GizmoModeKind::Translate,
+            Self::ScaleX
+            | Self::ScaleY
+            | Self::ScaleZ
+            | Self::ScaleXY
+            | Self::ScaleXZ
+            | Self::ScaleYZ
+            | Self::ScaleUniform => GizmoModeKind::Scale,
+            Self::Arcball => GizmoModeKind::Arcball,
         }
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd)]
 pub enum GizmoModeKind {
     Rotate,
     Translate,

--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -378,10 +378,9 @@ impl GizmoMode {
 
     pub fn kind(&self) -> GizmoModeKind {
         match self {
-            Self::RotateX
-            | Self::RotateY
-            | Self::RotateZ
-            | Self::RotateView => GizmoModeKind::Rotate,
+            Self::RotateX | Self::RotateY | Self::RotateZ | Self::RotateView => {
+                GizmoModeKind::Rotate
+            }
             Self::TranslateX
             | Self::TranslateY
             | Self::TranslateZ

--- a/crates/transform-gizmo/src/gizmo.rs
+++ b/crates/transform-gizmo/src/gizmo.rs
@@ -310,10 +310,10 @@ impl Gizmo {
     fn pick_subgizmo(&mut self, ray: Ray) -> Option<&mut SubGizmo> {
         // If mode is overridden, assume we only have that mode, and choose it.
         if self.config.mode_override.is_some() {
-            return self.subgizmos.first_mut().and_then(|subgizmo| {
+            return self.subgizmos.first_mut().map(|subgizmo| {
                 subgizmo.pick(ray);
 
-                Some(subgizmo)
+                subgizmo
             });
         }
 
@@ -332,8 +332,7 @@ impl Gizmo {
     fn enabled_modes(&self) -> EnumSet<GizmoMode> {
         self.config
             .mode_override
-            .map(EnumSet::only)
-            .unwrap_or(self.config.modes)
+            .map_or(self.config.modes, EnumSet::only)
     }
 
     /// Adds rotation subgizmos

--- a/crates/transform-gizmo/src/gizmo.rs
+++ b/crates/transform-gizmo/src/gizmo.rs
@@ -523,10 +523,7 @@ impl Gizmo {
             );
         }
 
-        if modes.contains(GizmoMode::ScaleUniform)
-            && !modes.contains(GizmoMode::RotateView)
-            && !modes.contains(GizmoMode::TranslateView)
-        {
+        if modes.contains(GizmoMode::ScaleUniform) && !modes.contains(GizmoMode::RotateView) {
             self.subgizmos.push(
                 ScaleSubGizmo::new(
                     self.config,

--- a/crates/transform-gizmo/src/gizmo.rs
+++ b/crates/transform-gizmo/src/gizmo.rs
@@ -58,19 +58,9 @@ impl Gizmo {
         self.config.update_for_config(config);
 
         if self.subgizmos.is_empty() {
-            for mode in self.config.modes {
-                match mode {
-                    GizmoMode::Rotate => {
-                        self.add_rotation();
-                    }
-                    GizmoMode::Translate => {
-                        self.add_translation();
-                    }
-                    GizmoMode::Scale => {
-                        self.add_scale();
-                    }
-                };
-            }
+            self.add_rotation();
+            self.add_translation();
+            self.add_scale();
         }
     }
 
@@ -328,145 +318,114 @@ impl Gizmo {
 
     /// Adds rotation subgizmos
     fn add_rotation(&mut self) {
-        self.subgizmos.extend([
-            RotationSubGizmo::new(
-                self.config,
-                RotationParams {
-                    direction: GizmoDirection::X,
-                },
-            )
-            .into(),
-            RotationSubGizmo::new(
-                self.config,
-                RotationParams {
-                    direction: GizmoDirection::Y,
-                },
-            )
-            .into(),
-            RotationSubGizmo::new(
-                self.config,
-                RotationParams {
-                    direction: GizmoDirection::Z,
-                },
-            )
-            .into(),
-            RotationSubGizmo::new(
-                self.config,
-                RotationParams {
-                    direction: GizmoDirection::View,
-                },
-            )
-            .into(),
-        ]);
+        let modes = self.config.modes;
 
-        self.subgizmos
-            .push(ArcballSubGizmo::new(self.config, ()).into());
+        if modes.contains(GizmoMode::RotateX) {
+            self.subgizmos.push(
+                RotationSubGizmo::new(
+                    self.config,
+                    RotationParams {
+                        direction: GizmoDirection::X,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::RotateY) {
+            self.subgizmos.push(
+                RotationSubGizmo::new(
+                    self.config,
+                    RotationParams {
+                        direction: GizmoDirection::Y,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::RotateZ) {
+            self.subgizmos.push(
+                RotationSubGizmo::new(
+                    self.config,
+                    RotationParams {
+                        direction: GizmoDirection::Z,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::RotateView) {
+            self.subgizmos.push(
+                RotationSubGizmo::new(
+                    self.config,
+                    RotationParams {
+                        direction: GizmoDirection::View,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::Arcball) {
+            self.subgizmos
+                .push(ArcballSubGizmo::new(self.config, ()).into());
+        }
     }
 
     /// Adds translation subgizmos
     fn add_translation(&mut self) {
-        self.subgizmos.extend([
-            TranslationSubGizmo::new(
-                self.config,
-                TranslationParams {
-                    direction: GizmoDirection::X,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-            TranslationSubGizmo::new(
-                self.config,
-                TranslationParams {
-                    direction: GizmoDirection::Y,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-            TranslationSubGizmo::new(
-                self.config,
-                TranslationParams {
-                    direction: GizmoDirection::Z,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-            TranslationSubGizmo::new(
-                self.config,
-                TranslationParams {
-                    direction: GizmoDirection::View,
-                    transform_kind: TransformKind::Plane,
-                },
-            )
-            .into(),
-        ]);
+        let modes = self.config.modes;
 
-        // Plane subgizmos are not added when both translation and scaling are enabled.
-        if !self.config.modes.contains(GizmoMode::Scale) {
-            self.subgizmos.extend([
-                TranslationSubGizmo::new(
-                    self.config,
-                    TranslationParams {
-                        direction: GizmoDirection::X,
-                        transform_kind: TransformKind::Plane,
-                    },
-                )
-                .into(),
-                TranslationSubGizmo::new(
-                    self.config,
-                    TranslationParams {
-                        direction: GizmoDirection::Y,
-                        transform_kind: TransformKind::Plane,
-                    },
-                )
-                .into(),
-                TranslationSubGizmo::new(
-                    self.config,
-                    TranslationParams {
-                        direction: GizmoDirection::Z,
-                        transform_kind: TransformKind::Plane,
-                    },
-                )
-                .into(),
-            ]);
-        }
-    }
-
-    /// Adds scale subgizmos
-    fn add_scale(&mut self) {
-        self.subgizmos.extend([
-            ScaleSubGizmo::new(
-                self.config,
-                ScaleParams {
-                    direction: GizmoDirection::X,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-            ScaleSubGizmo::new(
-                self.config,
-                ScaleParams {
-                    direction: GizmoDirection::Y,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-            ScaleSubGizmo::new(
-                self.config,
-                ScaleParams {
-                    direction: GizmoDirection::Z,
-                    transform_kind: TransformKind::Axis,
-                },
-            )
-            .into(),
-        ]);
-
-        // Uniform scaling subgizmo is added when only scaling is enabled.
-        // Otherwise it would overlap with rotation or translation subgizmos.
-        if self.config.modes.len() == 1 {
+        if modes.contains(GizmoMode::TranslateX) {
             self.subgizmos.push(
-                ScaleSubGizmo::new(
+                TranslationSubGizmo::new(
                     self.config,
-                    ScaleParams {
+                    TranslationParams {
+                        mode: GizmoMode::TranslateX,
+                        direction: GizmoDirection::X,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::TranslateY) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
+                    self.config,
+                    TranslationParams {
+                        mode: GizmoMode::TranslateY,
+                        direction: GizmoDirection::Y,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::TranslateZ) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
+                    self.config,
+                    TranslationParams {
+                        mode: GizmoMode::TranslateZ,
+                        direction: GizmoDirection::Z,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::TranslateView) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
+                    self.config,
+                    TranslationParams {
+                        mode: GizmoMode::TranslateView,
                         direction: GizmoDirection::View,
                         transform_kind: TransformKind::Plane,
                     },
@@ -475,34 +434,152 @@ impl Gizmo {
             );
         }
 
-        // Plane subgizmos are not added when both translation and scaling are enabled.
-        if !self.config.modes.contains(GizmoMode::Translate) {
-            self.subgizmos.extend([
-                ScaleSubGizmo::new(
+        if modes.contains(GizmoMode::TranslateXY) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
                     self.config,
-                    ScaleParams {
+                    TranslationParams {
+                        mode: GizmoMode::TranslateXY,
                         direction: GizmoDirection::X,
                         transform_kind: TransformKind::Plane,
                     },
                 )
                 .into(),
-                ScaleSubGizmo::new(
+            );
+        }
+
+        if modes.contains(GizmoMode::TranslateXZ) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
                     self.config,
-                    ScaleParams {
+                    TranslationParams {
+                        mode: GizmoMode::TranslateXZ,
                         direction: GizmoDirection::Y,
                         transform_kind: TransformKind::Plane,
                     },
                 )
                 .into(),
-                ScaleSubGizmo::new(
+            );
+        }
+
+        if modes.contains(GizmoMode::TranslateYZ) {
+            self.subgizmos.push(
+                TranslationSubGizmo::new(
                     self.config,
-                    ScaleParams {
+                    TranslationParams {
+                        mode: GizmoMode::TranslateYZ,
                         direction: GizmoDirection::Z,
                         transform_kind: TransformKind::Plane,
                     },
                 )
                 .into(),
-            ]);
+            );
+        }
+    }
+
+    /// Adds scale subgizmos
+    fn add_scale(&mut self) {
+        let modes = self.config.modes;
+
+        if modes.contains(GizmoMode::ScaleX) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleX,
+                        direction: GizmoDirection::X,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleY) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleY,
+                        direction: GizmoDirection::Y,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleZ) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleZ,
+                        direction: GizmoDirection::Z,
+                        transform_kind: TransformKind::Axis,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleUniform)
+            && !modes.contains(GizmoMode::RotateView)
+            && !modes.contains(GizmoMode::TranslateView)
+        {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleUniform,
+                        direction: GizmoDirection::View,
+                        transform_kind: TransformKind::Plane,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleXY) && !modes.contains(GizmoMode::TranslateXY) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleXY,
+                        direction: GizmoDirection::X,
+                        transform_kind: TransformKind::Plane,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleXZ) && !modes.contains(GizmoMode::TranslateXZ) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleXZ,
+                        direction: GizmoDirection::Y,
+                        transform_kind: TransformKind::Plane,
+                    },
+                )
+                .into(),
+            );
+        }
+
+        if modes.contains(GizmoMode::ScaleYZ) && !modes.contains(GizmoMode::TranslateYZ) {
+            self.subgizmos.push(
+                ScaleSubGizmo::new(
+                    self.config,
+                    ScaleParams {
+                        mode: GizmoMode::ScaleYZ,
+                        direction: GizmoDirection::Z,
+                        transform_kind: TransformKind::Plane,
+                    },
+                )
+                .into(),
+            );
         }
     }
 

--- a/crates/transform-gizmo/src/subgizmo/arcball.rs
+++ b/crates/transform-gizmo/src/subgizmo/arcball.rs
@@ -26,11 +26,12 @@ impl SubGizmoKind for Arcball {
             arcball_radius(&subgizmo.config),
             true,
         );
+
+        subgizmo.state.last_pos = ray.screen_pos;
+
         if !pick_result.picked {
             return None;
         }
-
-        subgizmo.state.last_pos = ray.screen_pos;
 
         Some(f64::MAX)
     }

--- a/crates/transform-gizmo/src/subgizmo/scale.rs
+++ b/crates/transform-gizmo/src/subgizmo/scale.rs
@@ -13,6 +13,7 @@ pub(crate) type ScaleSubGizmo = SubGizmoConfig<Scale>;
 
 #[derive(Debug, Copy, Clone, Hash)]
 pub(crate) struct ScaleParams {
+    pub mode: GizmoMode,
     pub direction: GizmoDirection,
     pub transform_kind: TransformKind,
 }
@@ -50,7 +51,7 @@ impl SubGizmoKind for Scale {
             }
             (TransformKind::Plane, _) => pick_plane(&subgizmo.config, ray, subgizmo.direction),
             (TransformKind::Axis, _) => {
-                pick_arrow(&subgizmo.config, ray, subgizmo.direction, GizmoMode::Scale)
+                pick_arrow(&subgizmo.config, ray, subgizmo.direction, subgizmo.mode)
             }
         };
 
@@ -98,7 +99,7 @@ impl SubGizmoKind for Scale {
                 subgizmo.opacity,
                 subgizmo.focused,
                 subgizmo.direction,
-                GizmoMode::Scale,
+                subgizmo.mode,
             ),
             (TransformKind::Plane, GizmoDirection::View) => {
                 draw_circle(

--- a/crates/transform-gizmo/src/subgizmo/scale.rs
+++ b/crates/transform-gizmo/src/subgizmo/scale.rs
@@ -3,8 +3,8 @@ use glam::DVec3;
 use crate::math::{round_to_interval, world_to_screen, Pos2};
 
 use crate::subgizmo::common::{
-    draw_arrow, draw_circle, draw_plane, gizmo_color, gizmo_local_normal, inner_circle_radius,
-    outer_circle_radius, pick_arrow, pick_circle, pick_plane, plane_bitangent, plane_tangent,
+    draw_arrow, draw_circle, draw_plane, gizmo_color, gizmo_local_normal, outer_circle_radius,
+    pick_arrow, pick_circle, pick_plane, plane_bitangent, plane_tangent,
 };
 use crate::subgizmo::{common::TransformKind, SubGizmoConfig, SubGizmoKind};
 use crate::{gizmo::Ray, GizmoDirection, GizmoDrawData, GizmoMode, GizmoResult};
@@ -32,23 +32,12 @@ impl SubGizmoKind for Scale {
 
     fn pick(subgizmo: &mut ScaleSubGizmo, ray: Ray) -> Option<f64> {
         let pick_result = match (subgizmo.transform_kind, subgizmo.direction) {
-            (TransformKind::Plane, GizmoDirection::View) => {
-                let mut result = pick_circle(
-                    &subgizmo.config,
-                    ray,
-                    inner_circle_radius(&subgizmo.config),
-                    true,
-                );
-                if !result.picked {
-                    result = pick_circle(
-                        &subgizmo.config,
-                        ray,
-                        outer_circle_radius(&subgizmo.config),
-                        false,
-                    );
-                }
-                result
-            }
+            (TransformKind::Plane, GizmoDirection::View) => pick_circle(
+                &subgizmo.config,
+                ray,
+                outer_circle_radius(&subgizmo.config),
+                false,
+            ),
             (TransformKind::Plane, _) => pick_plane(&subgizmo.config, ray, subgizmo.direction),
             (TransformKind::Axis, _) => {
                 pick_arrow(&subgizmo.config, ray, subgizmo.direction, subgizmo.mode)
@@ -101,19 +90,12 @@ impl SubGizmoKind for Scale {
                 subgizmo.direction,
                 subgizmo.mode,
             ),
-            (TransformKind::Plane, GizmoDirection::View) => {
-                draw_circle(
-                    &subgizmo.config,
-                    gizmo_color(&subgizmo.config, subgizmo.focused, subgizmo.direction),
-                    inner_circle_radius(&subgizmo.config),
-                    false,
-                ) + draw_circle(
-                    &subgizmo.config,
-                    gizmo_color(&subgizmo.config, subgizmo.focused, subgizmo.direction),
-                    outer_circle_radius(&subgizmo.config),
-                    false,
-                )
-            }
+            (TransformKind::Plane, GizmoDirection::View) => draw_circle(
+                &subgizmo.config,
+                gizmo_color(&subgizmo.config, subgizmo.focused, subgizmo.direction),
+                outer_circle_radius(&subgizmo.config),
+                false,
+            ),
             (TransformKind::Plane, _) => draw_plane(
                 &subgizmo.config,
                 subgizmo.opacity,

--- a/crates/transform-gizmo/src/subgizmo/translation.rs
+++ b/crates/transform-gizmo/src/subgizmo/translation.rs
@@ -11,6 +11,7 @@ pub(crate) type TranslationSubGizmo = SubGizmoConfig<Translation>;
 
 #[derive(Debug, Copy, Clone, Hash)]
 pub(crate) struct TranslationParams {
+    pub mode: GizmoMode,
     pub direction: GizmoDirection,
     pub transform_kind: TransformKind,
 }
@@ -38,12 +39,9 @@ impl SubGizmoKind for Translation {
                 true,
             ),
             (TransformKind::Plane, _) => pick_plane(&subgizmo.config, ray, subgizmo.direction),
-            (TransformKind::Axis, _) => pick_arrow(
-                &subgizmo.config,
-                ray,
-                subgizmo.direction,
-                GizmoMode::Translate,
-            ),
+            (TransformKind::Axis, _) => {
+                pick_arrow(&subgizmo.config, ray, subgizmo.direction, subgizmo.mode)
+            }
         };
 
         subgizmo.opacity = pick_result.visibility as _;
@@ -106,7 +104,7 @@ impl SubGizmoKind for Translation {
                 subgizmo.opacity,
                 subgizmo.focused,
                 subgizmo.direction,
-                GizmoMode::Translate,
+                subgizmo.mode,
             ),
             (TransformKind::Plane, GizmoDirection::View) => draw_circle(
                 &subgizmo.config,

--- a/examples/bevy/src/gui.rs
+++ b/examples/bevy/src/gui.rs
@@ -1,6 +1,6 @@
 use bevy::{math::DQuat, prelude::*};
 use bevy_egui::{
-    egui::{self, Layout, Widget},
+    egui::{self, Layout, RichText, Widget},
     EguiContexts, EguiPlugin,
 };
 use transform_gizmo_bevy::{
@@ -105,21 +105,74 @@ fn draw_options(ui: &mut egui::Ui, gizmo_options: &mut GizmoOptions) {
     ui.heading("Options");
     ui.separator();
 
+    egui::Grid::new("modes_grid").num_columns(7).show(ui, |ui| {
+        ui.label(RichText::new("Mode").strong());
+        ui.label(RichText::new("View").strong());
+        ui.label(RichText::new("X").strong());
+        ui.label(RichText::new("Y").strong());
+        ui.label(RichText::new("Z").strong());
+        ui.label(RichText::new("XZ").strong());
+        ui.label(RichText::new("XY").strong());
+        ui.label(RichText::new("YZ").strong());
+        ui.end_row();
+
+        ui.label("Rotation");
+        draw_mode_picker(ui, GizmoMode::RotateView, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::RotateX, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::RotateY, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::RotateZ, &mut gizmo_options.gizmo_modes);
+        ui.end_row();
+
+        ui.label("Translation");
+        draw_mode_picker(ui, GizmoMode::TranslateView, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateX, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateY, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateZ, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateXZ, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateXY, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::TranslateYZ, &mut gizmo_options.gizmo_modes);
+        ui.end_row();
+
+        ui.label("Scale");
+        ui.add_enabled_ui(
+            !gizmo_options.gizmo_modes.contains(GizmoMode::RotateView),
+            |ui| {
+                draw_mode_picker(ui, GizmoMode::ScaleUniform, &mut gizmo_options.gizmo_modes);
+            },
+        );
+        draw_mode_picker(ui, GizmoMode::ScaleX, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::ScaleY, &mut gizmo_options.gizmo_modes);
+        draw_mode_picker(ui, GizmoMode::ScaleZ, &mut gizmo_options.gizmo_modes);
+        ui.add_enabled_ui(
+            !gizmo_options.gizmo_modes.contains(GizmoMode::TranslateXZ),
+            |ui| {
+                draw_mode_picker(ui, GizmoMode::ScaleXZ, &mut gizmo_options.gizmo_modes);
+            },
+        );
+        ui.add_enabled_ui(
+            !gizmo_options.gizmo_modes.contains(GizmoMode::TranslateXY),
+            |ui| {
+                draw_mode_picker(ui, GizmoMode::ScaleXY, &mut gizmo_options.gizmo_modes);
+            },
+        );
+        ui.add_enabled_ui(
+            !gizmo_options.gizmo_modes.contains(GizmoMode::TranslateYZ),
+            |ui| {
+                draw_mode_picker(ui, GizmoMode::ScaleYZ, &mut gizmo_options.gizmo_modes);
+            },
+        );
+        ui.end_row();
+
+        ui.label("Arcball");
+        draw_mode_picker(ui, GizmoMode::Arcball, &mut gizmo_options.gizmo_modes);
+        ui.end_row();
+    });
+
+    ui.separator();
+
     egui::Grid::new("options_grid")
         .num_columns(2)
         .show(ui, |ui| {
-            ui.label("Allow rotation");
-            draw_mode_picker(ui, GizmoMode::Rotate, &mut gizmo_options.gizmo_modes);
-            ui.end_row();
-
-            ui.label("Allow translation");
-            draw_mode_picker(ui, GizmoMode::Translate, &mut gizmo_options.gizmo_modes);
-            ui.end_row();
-
-            ui.label("Allow scaling");
-            draw_mode_picker(ui, GizmoMode::Scale, &mut gizmo_options.gizmo_modes);
-            ui.end_row();
-
             ui.label("Orientation");
             egui::ComboBox::from_id_source("orientation_cb")
                 .selected_text(format!("{:?}", gizmo_options.gizmo_orientation))
@@ -206,15 +259,15 @@ fn draw_options(ui: &mut egui::Ui, gizmo_options: &mut GizmoOptions) {
     });
 }
 
-fn draw_mode_picker(ui: &mut egui::Ui, mode: GizmoMode, modes: &mut EnumSet<GizmoMode>) {
-    let mut checked = modes.contains(mode);
+fn draw_mode_picker(ui: &mut egui::Ui, mode: GizmoMode, all_modes: &mut EnumSet<GizmoMode>) {
+    let mut checked = all_modes.contains(mode);
 
     egui::Checkbox::without_text(&mut checked).ui(ui);
 
     if checked {
-        modes.insert(mode);
+        all_modes.insert(mode);
     } else {
-        modes.remove(mode);
+        all_modes.remove(mode);
     }
 }
 

--- a/examples/bevy/src/gui.rs
+++ b/examples/bevy/src/gui.rs
@@ -3,10 +3,7 @@ use bevy_egui::{
     egui::{self, Layout, RichText, Widget},
     EguiContexts, EguiPlugin,
 };
-use transform_gizmo_bevy::{
-    config::{TransformPivotPoint, DEFAULT_SNAP_ANGLE, DEFAULT_SNAP_DISTANCE, DEFAULT_SNAP_SCALE},
-    prelude::*,
-};
+use transform_gizmo_bevy::{config::TransformPivotPoint, prelude::*};
 
 pub struct GuiPlugin;
 
@@ -19,27 +16,8 @@ impl Plugin for GuiPlugin {
 fn update_ui(
     mut contexts: EguiContexts,
     mut gizmo_options: ResMut<GizmoOptions>,
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-
     gizmo_targets: Query<&GizmoTarget>,
 ) {
-    // Snapping is enabled when CTRL is pressed.
-    let snapping = keyboard_input.pressed(KeyCode::ControlLeft);
-    // Accurate snapping is enabled when both CTRL and SHIFT are pressed
-    let accurate_snapping = snapping && keyboard_input.pressed(KeyCode::ShiftLeft);
-
-    gizmo_options.snapping = snapping;
-
-    gizmo_options.snap_angle = DEFAULT_SNAP_ANGLE;
-    gizmo_options.snap_distance = DEFAULT_SNAP_DISTANCE;
-    gizmo_options.snap_scale = DEFAULT_SNAP_SCALE;
-
-    if accurate_snapping {
-        gizmo_options.snap_angle /= 2.0;
-        gizmo_options.snap_distance /= 2.0;
-        gizmo_options.snap_scale /= 2.0;
-    }
-
     egui::SidePanel::left("options").show(contexts.ctx_mut(), |ui| {
         draw_options(ui, &mut gizmo_options);
     });

--- a/examples/bevy/src/gui.rs
+++ b/examples/bevy/src/gui.rs
@@ -57,7 +57,7 @@ fn draw_gizmo_result(ui: &mut egui::Ui, gizmo_result: Option<GizmoResult>) {
                 )
             }
             GizmoResult::Scale { total } => {
-                format!("Scale: ({:.2}, {:.2}, {:.2})", total.x, total.y, total.z,)
+                format!("Scale: ({:.2}, {:.2}, {:.2})", total.x, total.y, total.z, )
             }
             GizmoResult::Arcball { delta: _, total } => {
                 let (axis, angle) = DQuat::from(total).to_axis_angle();
@@ -229,11 +229,13 @@ fn draw_options(ui: &mut egui::Ui, gizmo_options: &mut GizmoOptions) {
 
     ui.separator();
 
-    ui.with_layout(Layout::bottom_up(egui::Align::Center), |ui| {
+    ui.with_layout(Layout::bottom_up(egui::Align::Min), |ui| {
         egui::Hyperlink::from_label_and_url("(source code)", "https://github.com/urholaukkarinen/transform-gizmo/blob/main/examples/bevy/src/main.rs").ui(ui);
 
-        ui.label("Move and rotate the camera using the middle and right mouse buttons");
-        ui.label("Toggle gizmo snapping with left ctrl & shift");
+        ui.label(r#"Move and rotate the camera using the middle and right mouse buttons.
+Toggle gizmo snapping with left ctrl & shift.
+You can enter transform mode for translation, rotation and scale with by pressing G, R or S respectively.
+Transform mode can be exited with Esc or by pressing any mouse button."#);
     });
 }
 

--- a/examples/bevy/src/gui.rs
+++ b/examples/bevy/src/gui.rs
@@ -57,7 +57,7 @@ fn draw_gizmo_result(ui: &mut egui::Ui, gizmo_result: Option<GizmoResult>) {
                 )
             }
             GizmoResult::Scale { total } => {
-                format!("Scale: ({:.2}, {:.2}, {:.2})", total.x, total.y, total.z, )
+                format!("Scale: ({:.2}, {:.2}, {:.2})", total.x, total.y, total.z,)
             }
             GizmoResult::Arcball { delta: _, total } => {
                 let (axis, angle) = DQuat::from(total).to_axis_angle();

--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -3,6 +3,7 @@ use camera::PanOrbitCameraPlugin;
 use gui::GuiPlugin;
 use picking::PickingPlugin;
 use scene::ScenePlugin;
+use transform_gizmo_bevy::GizmoHotkeys;
 
 use transform_gizmo_bevy::prelude::*;
 
@@ -28,8 +29,7 @@ fn main() {
         .add_plugins(TransformGizmoPlugin)
         .add_plugins(PickingPlugin)
         .insert_resource(GizmoOptions {
-            gizmo_modes: GizmoMode::all(),
-            gizmo_orientation: GizmoOrientation::Global,
+            hotkeys: Some(GizmoHotkeys::default()),
             ..default()
         })
         .run();

--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         .add_plugins(TransformGizmoPlugin)
         .add_plugins(PickingPlugin)
         .insert_resource(GizmoOptions {
-            gizmo_modes: enum_set!(GizmoMode::Rotate | GizmoMode::Translate | GizmoMode::Scale),
+            gizmo_modes: GizmoMode::all(),
             gizmo_orientation: GizmoOrientation::Global,
             ..default()
         })

--- a/examples/bevy/src/scene.rs
+++ b/examples/bevy/src/scene.rs
@@ -9,7 +9,7 @@ use crate::camera::PanOrbitCamera;
 pub struct ScenePlugin;
 
 impl Plugin for ScenePlugin {
-    fn build(&self, app: &mut bevy::prelude::App) {
+    fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_scene);
     }
 }

--- a/examples/egui/src/main.rs
+++ b/examples/egui/src/main.rs
@@ -20,7 +20,7 @@ impl ExampleApp {
     fn new() -> Self {
         Self {
             gizmo: Gizmo::default(),
-            gizmo_modes: enum_set!(GizmoMode::Rotate | GizmoMode::Translate),
+            gizmo_modes: GizmoMode::all(),
             gizmo_orientation: GizmoOrientation::Local,
             scale: DVec3::ONE,
             rotation: DQuat::IDENTITY,
@@ -119,7 +119,7 @@ impl ExampleApp {
                 egui::ComboBox::from_id_source("mode_cb")
                     .selected_text(format!("{}", self.gizmo_modes.len()))
                     .show_ui(ui, |ui| {
-                        for mode in [GizmoMode::Rotate, GizmoMode::Translate, GizmoMode::Scale] {
+                        for mode in GizmoMode::all() {
                             let mut mode_selected = self.gizmo_modes.contains(mode);
                             ui.toggle_value(&mut mode_selected, format!("{:?}", mode));
                             if mode_selected {


### PR DESCRIPTION
You can now configure each individual subgizmo separately. For example, you could configure the gizmo to only have a Z translation arrow and arcball rotation.

You can also configure a bunch of hotkeys that can be used to toggle different transformation modes without having to manually interact with the gizmo. This works very similarly compared to Blender. The hotkeys are disabled by default, but can be enabled via `GizmoConfig`. `GizmoHotkeys::default()` includes some sensible defaults.