### PR TITLE
Update egui to 0.28 and glam to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ transform-gizmo = { version = "0.2.0", path = "crates/transform-gizmo" }
 transform-gizmo-egui = { version = "0.2.0", path = "crates/transform-gizmo-egui" }
 transform-gizmo-bevy = { version = "0.2.0", path = "crates/transform-gizmo-bevy" }
 
-egui = "0.27.2"
-eframe = "0.27.2"
-emath = "0.27.2"
-epaint = "0.27.2"
-ecolor = "0.27.2"
-glam = { version = "0.27.0", features = ["mint"] }
+egui = "0.28.0"
+eframe = "0.28.0"
+emath = "0.28.0"
+epaint = "0.28.0"
+ecolor = "0.28.0"
+glam = { version = "0.28.0", features = ["mint"] }
 mint = "0.5"
 enum_dispatch = "0.3.12"
 ahash = "0.8.7"

--- a/examples/egui/src/main.rs
+++ b/examples/egui/src/main.rs
@@ -162,10 +162,10 @@ impl eframe::App for ExampleApp {
     }
 }
 
-fn main() -> eframe::Result<()> {
+fn main() -> eframe::Result {
     eframe::run_native(
         "transform_gizmo_egui example",
         NativeOptions::default(),
-        Box::new(|_| Box::new(ExampleApp::new())),
+        Box::new(|_| Ok(Box::new(ExampleApp::new()))),
     )
 }


### PR DESCRIPTION
For glam, this is transparent and didn't require any change.
egui replaced some `Stroke` with `PathStroke` (strokes that can have a uv callback to get the color instead of a single `Color32` for the whole stroke). I updated `shape.rs`  to take it into account. Only `arrow(..)` still uses a `Stroke` since it uses its color to fill the shape. Since the functions uses into conversions in their signatures this is also transparent outside of the file.