### PR TITLE
Upgrade to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,22 +26,22 @@ mint = "0.5"
 enum_dispatch = "0.3.12"
 ahash = "0.8.7"
 enumset = "1.1.3"
-bevy = "0.13"
+bevy = "0.14.0-rc"
 
-bevy_app = { version = "0.13", default-features = false }
-bevy_core = { version = "0.13", default-features = false }
-bevy_core_pipeline = { version = "0.13", default-features = false }
-bevy_reflect = { version = "0.13", default-features = false }
-bevy_math = { version = "0.13", features = ["mint"], default-features = false }
-bevy_render = { version = "0.13", default-features = false }
-bevy_input = { version = "0.13", default-features = false }
-bevy_asset = { version = "0.13", default-features = false }
-bevy_utils = { version = "0.13", default-features = false }
-bevy_pbr = { version = "0.13", default-features = false }
-bevy_ecs = { version = "0.13", default-features = false }
-bevy_log = { version = "0.13", default-features = false }
-bevy_window = { version = "0.13", default-features = false }
-bevy_transform = { version = "0.13", default-features = false }
+bevy_app = { version = "0.14.0-rc", default-features = false }
+bevy_core = { version = "0.14.0-rc", default-features = false }
+bevy_core_pipeline = { version = "0.14.0-rc", default-features = false }
+bevy_reflect = { version = "0.14.0-rc", default-features = false }
+bevy_math = { version = "0.14.0-rc", features = ["mint"], default-features = false }
+bevy_render = { version = "0.14.0-rc", default-features = false }
+bevy_input = { version = "0.14.0-rc", default-features = false }
+bevy_asset = { version = "0.14.0-rc", default-features = false }
+bevy_utils = { version = "0.14.0-rc", default-features = false }
+bevy_pbr = { version = "0.14.0-rc", default-features = false }
+bevy_ecs = { version = "0.14.0-rc", default-features = false }
+bevy_log = { version = "0.14.0-rc", default-features = false }
+bevy_window = { version = "0.14.0-rc", default-features = false }
+bevy_transform = { version = "0.14.0-rc", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,22 +28,22 @@ ahash = "0.8.7"
 enumset = "1.1.3"
 bytemuck = "1.5"
 uuid = "1.1"
-bevy = "0.14.0-rc"
+bevy = "0.14"
 
-bevy_app = { version = "0.14.0-rc", default-features = false }
-bevy_core = { version = "0.14.0-rc", default-features = false }
-bevy_core_pipeline = { version = "0.14.0-rc", default-features = false }
-bevy_reflect = { version = "0.14.0-rc", default-features = false }
-bevy_math = { version = "0.14.0-rc", features = ["mint"], default-features = false }
-bevy_render = { version = "0.14.0-rc", default-features = false }
-bevy_input = { version = "0.14.0-rc", default-features = false }
-bevy_asset = { version = "0.14.0-rc", default-features = false }
-bevy_utils = { version = "0.14.0-rc", default-features = false }
-bevy_pbr = { version = "0.14.0-rc", default-features = false }
-bevy_ecs = { version = "0.14.0-rc", default-features = false }
-bevy_log = { version = "0.14.0-rc", default-features = false }
-bevy_window = { version = "0.14.0-rc", default-features = false }
-bevy_transform = { version = "0.14.0-rc", default-features = false }
+bevy_app = { version = "0.14", default-features = false }
+bevy_core = { version = "0.14", default-features = false }
+bevy_core_pipeline = { version = "0.14", default-features = false }
+bevy_reflect = { version = "0.14", default-features = false }
+bevy_math = { version = "0.14", features = ["mint"], default-features = false }
+bevy_render = { version = "0.14", default-features = false }
+bevy_input = { version = "0.14", default-features = false }
+bevy_asset = { version = "0.14", default-features = false }
+bevy_utils = { version = "0.14", default-features = false }
+bevy_pbr = { version = "0.14", default-features = false }
+bevy_ecs = { version = "0.14", default-features = false }
+bevy_log = { version = "0.14", default-features = false }
+bevy_window = { version = "0.14", default-features = false }
+bevy_transform = { version = "0.14", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ mint = "0.5"
 enum_dispatch = "0.3.12"
 ahash = "0.8.7"
 enumset = "1.1.3"
+bytemuck = "1.5"
+uuid = "1.1"
 bevy = "0.14.0-rc"
 
 bevy_app = { version = "0.14.0-rc", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "examples/*"]
 
 [workspace.package]
 version = "0.2.0"
-rust-version = "1.77.0"
+rust-version = "1.79.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/urholaukkarinen/transform-gizmo"

--- a/crates/transform-gizmo-bevy/Cargo.toml
+++ b/crates/transform-gizmo-bevy/Cargo.toml
@@ -40,7 +40,7 @@ bytemuck.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-bevy = "0.14.0-rc"
+bevy = "0.14"
 
 [lints]
 workspace = true

--- a/crates/transform-gizmo-bevy/Cargo.toml
+++ b/crates/transform-gizmo-bevy/Cargo.toml
@@ -38,7 +38,7 @@ bevy_window.workspace = true
 bevy_transform.workspace = true
 
 [dev-dependencies]
-bevy = "0.13"
+bevy = "0.14.0-rc"
 
 [lints]
 workspace = true

--- a/crates/transform-gizmo-bevy/Cargo.toml
+++ b/crates/transform-gizmo-bevy/Cargo.toml
@@ -36,6 +36,8 @@ bevy_ecs.workspace = true
 bevy_log.workspace = true
 bevy_window.workspace = true
 bevy_transform.workspace = true
+bytemuck.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 bevy = "0.14.0-rc"

--- a/crates/transform-gizmo-bevy/examples/bevy_minimal.rs
+++ b/crates/transform-gizmo-bevy/examples/bevy_minimal.rs
@@ -1,6 +1,7 @@
 //! A very simple example
 //! See the project root's `examples` directory for more examples
 
+use bevy::color::palettes::css::LIME;
 use bevy::prelude::*;
 use transform_gizmo_bevy::*;
 
@@ -30,7 +31,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-            material: materials.add(Color::GREEN),
+            material: materials.add(Color::from(LIME)),
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
             ..default()
         },

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -35,8 +35,9 @@ use bevy_input::prelude::*;
 use bevy_math::{DQuat, DVec3, Vec2};
 use bevy_render::prelude::*;
 use bevy_transform::prelude::*;
-use bevy_utils::{HashMap, Uuid};
+use bevy_utils::HashMap;
 use bevy_window::{PrimaryWindow, Window};
+use uuid::Uuid;
 
 use render::{DrawDataHandles, TransformGizmoRenderPlugin};
 use transform_gizmo::config::{

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -422,7 +422,7 @@ fn update_gizmos(
         Pos2::new(viewport.max.x, viewport.max.y),
     );
 
-    let projection_matrix = camera.projection_matrix();
+    let projection_matrix = camera.clip_from_view();
 
     let view_matrix = camera_transform.compute_matrix().inverse();
 

--- a/crates/transform-gizmo-bevy/src/render.rs
+++ b/crates/transform-gizmo-bevy/src/render.rs
@@ -46,7 +46,7 @@ impl Plugin for TransformGizmoRenderPlugin {
         app.init_resource::<DrawDataHandles>()
             .add_plugins(RenderAssetPlugin::<GizmoDrawData>::default());
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 
@@ -62,7 +62,7 @@ impl Plugin for TransformGizmoRenderPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
 

--- a/crates/transform-gizmo-bevy/src/render.rs
+++ b/crates/transform-gizmo-bevy/src/render.rs
@@ -133,7 +133,7 @@ impl RenderAsset for GizmoBuffers {
             contents: color_buffer_data,
         });
 
-        Ok(GizmoBuffers {
+        Ok(Self {
             index_buffer,
             position_buffer,
             color_buffer,

--- a/crates/transform-gizmo-bevy/src/render.rs
+++ b/crates/transform-gizmo-bevy/src/render.rs
@@ -17,8 +17,7 @@ use bevy_render::render_asset::{
     RenderAssets,
 };
 use bevy_render::render_phase::{
-    AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult, RenderPhase,
-    SetItemPipeline, TrackedRenderPass,
+    AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand, RenderCommandResult, RenderPhase, SetItemPipeline, TrackedRenderPass
 };
 use bevy_render::render_resource::{
     BlendState, Buffer, BufferInitDescriptor, BufferUsages, ColorTargetState, ColorWrites,
@@ -349,7 +348,7 @@ fn queue_transform_gizmos(
                 pipeline,
                 distance: 0.,
                 batch_range: 0..1,
-                dynamic_offset: None,
+                extra_index: PhaseItemExtraIndex::NONE,
             });
         }
     }

--- a/crates/transform-gizmo-bevy/src/render.rs
+++ b/crates/transform-gizmo-bevy/src/render.rs
@@ -1,6 +1,5 @@
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Asset, Handle};
-use bevy_core::cast_slice;
 use bevy_core_pipeline::core_3d::{Transparent3d, CORE_3D_DEPTH_FORMAT};
 use bevy_core_pipeline::prepass::{
     DeferredPrepass, DepthPrepass, MotionVectorPrepass, NormalPrepass,
@@ -32,7 +31,9 @@ use bevy_render::renderer::RenderDevice;
 use bevy_render::texture::BevyDefault;
 use bevy_render::view::{ExtractedView, RenderLayers, ViewTarget};
 use bevy_render::{Extract, Render, RenderApp, RenderSet};
-use bevy_utils::{HashMap, HashSet, Uuid};
+use bevy_utils::{HashMap, HashSet};
+use bytemuck::cast_slice;
+use uuid::Uuid;
 
 const GIZMO_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812681337026784);
 

--- a/examples/bevy/Cargo.toml
+++ b/examples/bevy/Cargo.toml
@@ -13,13 +13,12 @@ publish = false
 transform-gizmo-bevy.workspace = true
 
 bevy.workspace = true
-bevy_infinite_grid = { git = "https://github.com/XYCaptain/bevy_infinite_grid.git", rev = "1e5259a52a7dfaca65402c2c57c1d81c2bc443e9" }
-bevy_mod_picking = "0.18.0"
-bevy_mod_outline = "0.7.0"
+bevy_infinite_grid = { git = "https://github.com/tychedelia/bevy_infinite_grid.git", rev = "4044e3219868d82a7db4326a48af58f829c109aa" }
+bevy_mod_picking = "0.20.0"
+bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline.git", rev = "d24b2eaec26b02f91ef99ebf0d86b982ea05a0ed" }
 
 [dependencies.bevy_egui]
-git = "https://github.com/mvlabat/bevy_egui.git"
-rev = "cfd819ee9bdfb58101ac3efb6bcd4b6336860773"
+version = "0.28"
 features = ["open_url", "default_fonts", "render"]
 default-features = false
 

--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -15,7 +15,7 @@ mod scene;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::rgb_u8(20, 20, 20)))
+        .insert_resource(ClearColor(Color::srgb_u8(20, 20, 20)))
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "transform-gizmo-demo".into(),

--- a/examples/bevy/src/scene.rs
+++ b/examples/bevy/src/scene.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css::{BLUE, LIME, RED};
 use bevy::prelude::*;
 use bevy_mod_outline::*;
 use bevy_mod_picking::prelude::*;
@@ -37,7 +38,7 @@ fn setup_scene(
 
     let cube_count: i32 = 3;
 
-    let colors = [Color::RED, Color::GREEN, Color::BLUE];
+    let colors: [Color; 3] = [RED.into(), LIME.into(), BLUE.into()];
 
     for i in 0..cube_count {
         commands

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This PR allows transform-gizmo-bevy to be used with Bevy 0.14. Closes #66.

Before we merge this PR, we should probably take this opportunity to get #68 merged first (upgrade all the dependencies' versions at once).

----------------------------------------

Concretely, this implements the following migration steps:

- Upgrade bevy & its subcrates to 0.14
- Upgrade required rustc to 1.79.0 (from 1.77.0) as [required by Bevy](https://github.com/bevyengine/bevy/blob/v0.14.0/Cargo.toml#L13)
- https://github.com/bevyengine/bevy/pull/12313 : [Add bytemuck & util as dependencies](https://github.com/urholaukkarinen/transform-gizmo/commit/57657df4883efa47ec978097719ef08e62c2825b)
- https://github.com/bevyengine/bevy/pull/13489 : [Rename camera.projection_matrix to .clip_from_view](https://github.com/urholaukkarinen/transform-gizmo/commit/4c8e36d13c2f149a3ac5a92673b1bd44177ca23b)
- https://github.com/bevyengine/bevy/pull/9202 : [Match get_sub_app_mut as an Option](https://github.com/urholaukkarinen/transform-gizmo/commit/e6fc4ce9fde5d022b494aa168f78b669d263f19a)
- https://github.com/bevyengine/bevy/pull/12827 : [Impl RenderAssets for GizmoBuffers instead of GizmoDrawData](https://github.com/urholaukkarinen/transform-gizmo/commit/4c7fbeb485f5c0d25db2c504fdca52a822f7a192)
- https://github.com/bevyengine/bevy/pull/12889 : [Rename Transparent3d dynamic_offset to extra_index](https://github.com/urholaukkarinen/transform-gizmo/commit/9c053ad946492a7c6df9c613bd46deb93a644065)
- https://github.com/bevyengine/bevy/pull/12453 & https://github.com/bevyengine/bevy/pull/13277 : [Use ViewSortedRenderPhases<Transparent3d> instead of RenderPhase<Transparent3d>](https://github.com/urholaukkarinen/transform-gizmo/commit/b0998e448c11797dda98052c3efd6100ccbd1dec)
- https://github.com/bevyengine/bevy/pull/12163 : [Use RED, LIME, BLUE from bevy::color::palettes::css & Into<Color>](https://github.com/urholaukkarinen/transform-gizmo/commit/bd36b85000ef4fb7dc8144e5a3ec2aae59eb1ee3)