### PR TITLE
Lower the Rust requirements to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "examples/*"]
 
 [workspace.package]
 version = "0.3.0"
-rust-version = "1.79.0"
+rust-version = "1.78.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/urholaukkarinen/transform-gizmo"

--- a/crates/transform-gizmo-bevy/Cargo.toml
+++ b/crates/transform-gizmo-bevy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transform-gizmo-bevy"
 description = "bevy integration for transform-gizmo"
 version.workspace = true
-rust-version.workspace = true
+rust-version = "1.79.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/transform-gizmo-egui/Cargo.toml
+++ b/crates/transform-gizmo-egui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transform-gizmo-egui"
 description = "egui integration for transform-gizmo"
 version.workspace = true
-rust-version.workspace = true
+rust-version = "1.76.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/transform-gizmo/Cargo.toml
+++ b/crates/transform-gizmo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "transform-gizmo"
 description = "3D transformation gizmo"
 version.workspace = true
-rust-version.workspace = true
+rust-version = "1.76.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Requiring 1.79 is way too much. For example, nixOS unstable only has 1.78 right now.
This PR keeps 1.79 on Bevy-related stuff, while putting 1.76 on the rest.