### PR TITLE
Fixed painter clipping in transform-gizmo-egui (#71)

### DIFF
--- a/crates/transform-gizmo-egui/src/lib.rs
+++ b/crates/transform-gizmo-egui/src/lib.rs
@@ -96,7 +96,7 @@ impl GizmoExt for Gizmo {
 
         let draw_data = self.draw();
 
-        ui.painter().with_clip_rect(egui_viewport).add(Mesh {
+        egui::Painter::new(ui.ctx().clone(), ui.layer_id(), egui_viewport).add(Mesh {
             indices: draw_data.indices,
             vertices: draw_data
                 .vertices


### PR DESCRIPTION
Painter's clip rect was always a sub-region of the UI's clip rect, so it was not possible to draw outside the used UI. Now the whole gizmo viewport is used as clip rect