### PR TITLE
Fixed gizmo responding to mouse input through other UI elements (#73)

### DIFF
--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -454,6 +454,7 @@ fn update_gizmos(
 
     let gizmo_interaction = GizmoInteraction {
         cursor_pos: (cursor_pos.x, cursor_pos.y),
+        hovered: true,
         drag_started: mouse.just_pressed(MouseButton::Left),
         dragging: mouse.any_pressed([MouseButton::Left]),
     };

--- a/crates/transform-gizmo-egui/src/lib.rs
+++ b/crates/transform-gizmo-egui/src/lib.rs
@@ -44,7 +44,7 @@
 //! ```
 //!
 //!
-use egui::{epaint::Vertex, Mesh, PointerButton, Pos2, Rgba, Ui};
+use egui::{epaint::Vertex, Mesh, PointerButton, Pos2, Rgba, Sense, Ui, Vec2};
 
 use transform_gizmo::math::Transform;
 pub use transform_gizmo::*;
@@ -84,9 +84,17 @@ impl GizmoExt for Gizmo {
             ..*self.config()
         });
 
+        let interaction = ui.interact(
+            Rect::from_center_size(cursor_pos, Vec2::splat(1.0)),
+            ui.id().with("_interaction"),
+            Sense::click_and_drag(),
+        );
+        let hovered = interaction.hovered();
+
         let gizmo_result = self.update(
             GizmoInteraction {
                 cursor_pos: (cursor_pos.x, cursor_pos.y),
+                hovered: hovered,
                 drag_started: ui
                     .input(|input| input.pointer.button_pressed(PointerButton::Primary)),
                 dragging: ui.input(|input| input.pointer.button_down(PointerButton::Primary)),

--- a/crates/transform-gizmo-egui/src/lib.rs
+++ b/crates/transform-gizmo-egui/src/lib.rs
@@ -94,7 +94,7 @@ impl GizmoExt for Gizmo {
         let gizmo_result = self.update(
             GizmoInteraction {
                 cursor_pos: (cursor_pos.x, cursor_pos.y),
-                hovered: hovered,
+                hovered,
                 drag_started: ui
                     .input(|input| input.pointer.button_pressed(PointerButton::Primary)),
                 dragging: ui.input(|input| input.pointer.button_down(PointerButton::Primary)),

--- a/crates/transform-gizmo/src/gizmo.rs
+++ b/crates/transform-gizmo/src/gizmo.rs
@@ -81,10 +81,12 @@ impl Gizmo {
     /// # let cursor_pos = Default::default();
     /// # let drag_started = true;
     /// # let dragging = true;
+    /// # let hovered = true;
     /// # let mut transforms = vec![];
     ///
     /// let interaction = GizmoInteraction {
     ///     cursor_pos,
+    ///     hovered,
     ///     drag_started,
     ///     dragging
     /// };
@@ -130,7 +132,7 @@ impl Gizmo {
 
         // If there is no active subgizmo, find which one of them
         // is under the mouse pointer, if any.
-        if self.active_subgizmo_id.is_none() {
+        if self.active_subgizmo_id.is_none() && interaction.hovered {
             if let Some(subgizmo) = self.pick_subgizmo(pointer_ray) {
                 subgizmo.set_focused(true);
 
@@ -636,6 +638,11 @@ impl Gizmo {
 pub struct GizmoInteraction {
     /// Current cursor position in window coordinates.
     pub cursor_pos: (f32, f32),
+    /// Whether the gizmo is hovered this frame.
+    /// Some other UI element might be covering the gizmo,
+    /// and in such case you may not want the gizmo to be
+    /// interactable.
+    pub hovered: bool,
     /// Whether dragging was started this frame.
     /// Usually this is set to true if the primary mouse
     /// button was just pressed.


### PR DESCRIPTION
The gizmo can no longer be interacted with through other UI elements. For now this is only implemented in `transform-gizmo-egui`.