### PR TITLE
Fix spelling of `ShapeBuilder`

### DIFF
--- a/crates/transform-gizmo/src/shape.rs
+++ b/crates/transform-gizmo/src/shape.rs
@@ -10,13 +10,13 @@ use crate::math::world_to_screen;
 
 const STEPS_PER_RAD: f64 = 20.0;
 
-pub(crate) struct ShapeBuidler {
+pub(crate) struct ShapeBuilder {
     mvp: DMat4,
     viewport: Rect,
     pixels_per_point: f32,
 }
 
-impl ShapeBuidler {
+impl ShapeBuilder {
     pub(crate) fn new(mvp: DMat4, viewport: Rect, pixels_per_point: f32) -> Self {
         Self {
             mvp,

--- a/crates/transform-gizmo/src/subgizmo/common.rs
+++ b/crates/transform-gizmo/src/subgizmo/common.rs
@@ -4,7 +4,7 @@ use ecolor::Color32;
 use enumset::EnumSet;
 use std::ops::{Add, RangeInclusive};
 
-use crate::shape::ShapeBuidler;
+use crate::shape::ShapeBuilder;
 use crate::{config::PreparedGizmoConfig, gizmo::Ray, GizmoDirection, GizmoDrawData};
 use glam::{DMat3, DMat4, DQuat, DVec3};
 
@@ -190,7 +190,7 @@ pub(crate) fn draw_arrow(
         DMat4::from_translation(config.translation)
     };
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,
@@ -251,7 +251,7 @@ pub(crate) fn draw_plane(
         DMat4::from_translation(config.translation)
     };
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,
@@ -300,7 +300,7 @@ pub(crate) fn draw_circle(
 
     let transform = DMat4::from_rotation_translation(rotation, config.translation);
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,

--- a/crates/transform-gizmo/src/subgizmo/rotation.rs
+++ b/crates/transform-gizmo/src/subgizmo/rotation.rs
@@ -6,7 +6,7 @@ use crate::math::{
     ray_to_plane_origin, rotation_align, round_to_interval, world_to_screen, DMat3, DMat4, DQuat,
     DVec2, DVec3, Pos2,
 };
-use crate::shape::ShapeBuidler;
+use crate::shape::ShapeBuilder;
 use crate::subgizmo::common::{gizmo_color, gizmo_local_normal, gizmo_normal, outer_circle_radius};
 use crate::subgizmo::{SubGizmoConfig, SubGizmoKind};
 use crate::{gizmo::Ray, GizmoDirection, GizmoDrawData, GizmoResult};
@@ -111,7 +111,7 @@ impl SubGizmoKind for Rotation {
         let config = subgizmo.config;
 
         let transform = rotation_matrix(subgizmo);
-        let shape_builder = ShapeBuidler::new(
+        let shape_builder = ShapeBuilder::new(
             config.view_projection * transform,
             config.viewport,
             config.pixels_per_point,


### PR DESCRIPTION
This is a crate-internal API, so not a breaking change.