### PR TITLE
Update bevy 0.16, fix spelling, update web demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,25 +28,25 @@ ahash = "0.8"
 enumset = "1.1"
 bytemuck = "1.22"
 uuid = "1.1"
-bevy = "0.15"
+bevy = "0.16"
 
-bevy_app = { version = "0.15", default-features = false }
-bevy_core = { version = "0.15", default-features = false }
-bevy_core_pipeline = { version = "0.15", default-features = false }
-bevy_reflect = { version = "0.15", default-features = false }
-bevy_math = { version = "0.15", features = ["mint"], default-features = false }
-bevy_render = { version = "0.15", default-features = false }
-bevy_input = { version = "0.15", default-features = false }
-bevy_asset = { version = "0.15", default-features = false }
-bevy_utils = { version = "0.15", default-features = false }
-bevy_pbr = { version = "0.15", default-features = false }
-bevy_ecs = { version = "0.15", default-features = false }
-bevy_log = { version = "0.15", default-features = false }
-bevy_window = { version = "0.15", default-features = false }
-bevy_transform = { version = "0.15", default-features = false }
-bevy_derive = { version = "0.15", default-features = false }
-bevy_image = { version = "0.15", default-features = false }
-bevy_picking = { version = "0.15", default-features = false }
+bevy_app = { version = "0.16", default-features = false }
+bevy_core_pipeline = { version = "0.16", default-features = false }
+bevy_reflect = { version = "0.16", default-features = false }
+bevy_math = { version = "0.16", features = ["mint"], default-features = false }
+bevy_render = { version = "0.16", default-features = false }
+bevy_input = { version = "0.16", default-features = false }
+bevy_asset = { version = "0.16", default-features = false }
+bevy_utils = { version = "0.16", default-features = false }
+bevy_platform = { version = "0.16", default-features = false }
+bevy_pbr = { version = "0.16", default-features = false }
+bevy_ecs = { version = "0.16", default-features = false }
+bevy_log = { version = "0.16", default-features = false }
+bevy_window = { version = "0.16", default-features = false }
+bevy_transform = { version = "0.16", default-features = false }
+bevy_derive = { version = "0.16", default-features = false }
+bevy_image = { version = "0.16", default-features = false }
+bevy_picking = { version = "0.16", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/crates/transform-gizmo-bevy/Cargo.toml
+++ b/crates/transform-gizmo-bevy/Cargo.toml
@@ -21,7 +21,6 @@ mouse_interaction = []
 transform-gizmo.workspace = true
 
 bevy_app.workspace = true
-bevy_core.workspace = true
 bevy_core_pipeline.workspace = true
 bevy_reflect.workspace = true
 bevy_math.workspace = true
@@ -30,6 +29,7 @@ bevy_render.workspace = true
 bevy_input.workspace = true
 bevy_asset.workspace = true
 bevy_utils.workspace = true
+bevy_platform.workspace = true
 bevy_pbr.workspace = true
 bevy_ecs.workspace = true
 bevy_log.workspace = true

--- a/crates/transform-gizmo-bevy/examples/ui_blocked_gizmo.rs
+++ b/crates/transform-gizmo-bevy/examples/ui_blocked_gizmo.rs
@@ -10,7 +10,7 @@ fn main() {
         .add_plugins((DefaultPlugins, TransformGizmoPlugin))
         .add_systems(Startup, setup)
         .add_observer(|trigger: Trigger<Pointer<Over>>| {
-            info!("Moved over: {}", trigger.entity());
+            info!("Moved over: {}", trigger.target());
         })
         .run();
 }

--- a/crates/transform-gizmo-bevy/src/lib.rs
+++ b/crates/transform-gizmo-bevy/src/lib.rs
@@ -33,10 +33,10 @@ use bevy_asset::{AssetApp, Assets};
 use bevy_ecs::prelude::*;
 use bevy_input::prelude::*;
 use bevy_math::{DQuat, DVec3, Vec2};
-use bevy_picking::focus::HoverMap;
+use bevy_picking::hover::HoverMap;
+use bevy_platform::collections::HashMap;
 use bevy_render::prelude::*;
 use bevy_transform::prelude::*;
-use bevy_utils::HashMap;
 use bevy_window::{PrimaryWindow, Window};
 use mouse_interact::MouseGizmoInteractionPlugin;
 use picking::TransformGizmoPickingPlugin;
@@ -391,7 +391,7 @@ fn update_gizmos(
     mut last_scaled_cursor_pos: Local<Vec2>,
     #[cfg(feature = "gizmo_picking_backend")] hover_map: Res<HoverMap>,
 ) {
-    let Ok(window) = q_window.get_single() else {
+    let Ok(window) = q_window.single() else {
         // No primary window found.
         return;
     };

--- a/crates/transform-gizmo-bevy/src/mouse_interact.rs
+++ b/crates/transform-gizmo-bevy/src/mouse_interact.rs
@@ -17,10 +17,10 @@ fn mouse_interact_gizmo(
     mut dragging: EventWriter<GizmoDragging>,
 ) {
     if mouse.just_pressed(MouseButton::Left) {
-        drag_started.send_default();
+        drag_started.write_default();
     }
 
     if mouse.pressed(MouseButton::Left) {
-        dragging.send_default();
+        dragging.write_default();
     }
 }

--- a/crates/transform-gizmo-bevy/src/picking.rs
+++ b/crates/transform-gizmo-bevy/src/picking.rs
@@ -1,7 +1,7 @@
 use bevy_app::{Plugin, PreUpdate};
 use bevy_ecs::{
     event::EventWriter,
-    schedule::IntoSystemConfigs,
+    schedule::IntoScheduleConfigs,
     system::{Query, Res},
 };
 use bevy_picking::{
@@ -43,6 +43,6 @@ fn update_hits(
             .map(|(entity, _gizmo)| (*entity, HitData::new(*entity, 0.0, None, None)))
             .collect::<Vec<_>>();
 
-        output.send(PointerHits::new(*pointer_id, hits, 0.0));
+        output.write(PointerHits::new(*pointer_id, hits, 0.0));
     }
 }

--- a/crates/transform-gizmo/src/shape.rs
+++ b/crates/transform-gizmo/src/shape.rs
@@ -10,13 +10,13 @@ use crate::math::world_to_screen;
 
 const STEPS_PER_RAD: f64 = 20.0;
 
-pub(crate) struct ShapeBuidler {
+pub(crate) struct ShapeBuilder {
     mvp: DMat4,
     viewport: Rect,
     pixels_per_point: f32,
 }
 
-impl ShapeBuidler {
+impl ShapeBuilder {
     pub(crate) fn new(mvp: DMat4, viewport: Rect, pixels_per_point: f32) -> Self {
         Self {
             mvp,

--- a/crates/transform-gizmo/src/subgizmo/common.rs
+++ b/crates/transform-gizmo/src/subgizmo/common.rs
@@ -4,7 +4,7 @@ use ecolor::Color32;
 use enumset::EnumSet;
 use std::ops::{Add, RangeInclusive};
 
-use crate::shape::ShapeBuidler;
+use crate::shape::ShapeBuilder;
 use crate::{GizmoDirection, GizmoDrawData, config::PreparedGizmoConfig, gizmo::Ray};
 use glam::{DMat3, DMat4, DQuat, DVec3};
 
@@ -198,7 +198,7 @@ pub(crate) fn draw_arrow(
         DMat4::from_translation(config.translation)
     };
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,
@@ -259,7 +259,7 @@ pub(crate) fn draw_plane(
         DMat4::from_translation(config.translation)
     };
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,
@@ -308,7 +308,7 @@ pub(crate) fn draw_circle(
 
     let transform = DMat4::from_rotation_translation(rotation, config.translation);
 
-    let shape_builder = ShapeBuidler::new(
+    let shape_builder = ShapeBuilder::new(
         config.view_projection * transform,
         config.viewport,
         config.pixels_per_point,

--- a/crates/transform-gizmo/src/subgizmo/rotation.rs
+++ b/crates/transform-gizmo/src/subgizmo/rotation.rs
@@ -6,7 +6,7 @@ use crate::math::{
     DMat3, DMat4, DQuat, DVec2, DVec3, Pos2, ray_to_plane_origin, rotation_align,
     round_to_interval, world_to_screen,
 };
-use crate::shape::ShapeBuidler;
+use crate::shape::ShapeBuilder;
 use crate::subgizmo::common::{gizmo_color, gizmo_local_normal, gizmo_normal, outer_circle_radius};
 use crate::subgizmo::{SubGizmoConfig, SubGizmoKind};
 use crate::{GizmoDirection, GizmoDrawData, GizmoResult, gizmo::Ray};
@@ -143,7 +143,7 @@ impl SubGizmoKind for Rotation {
         let config = subgizmo.config;
 
         let transform = rotation_matrix(subgizmo);
-        let shape_builder = ShapeBuidler::new(
+        let shape_builder = ShapeBuilder::new(
             config.view_projection * transform,
             config.viewport,
             config.pixels_per_point,

--- a/docs/bevy-example.js
+++ b/docs/bevy-example.js
@@ -145,6 +145,11 @@ function getArrayU32FromWasm0(ptr, len) {
     return getUint32ArrayMemory0().subarray(ptr / 4, ptr / 4 + len);
 }
 
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+}
+
 let cachedUint8ClampedArrayMemory0 = null;
 
 function getUint8ClampedArrayMemory0() {
@@ -255,31 +260,31 @@ function debugString(val) {
     return className;
 }
 function __wbg_adapter_36(arg0, arg1, arg2) {
-    wasm.closure4437_externref_shim(arg0, arg1, arg2);
+    wasm.closure5122_externref_shim(arg0, arg1, arg2);
 }
 
 function __wbg_adapter_43(arg0, arg1, arg2) {
-    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hffaaea17539fadee(arg0, arg1, isLikeNone(arg2) ? 0 : addToExternrefTable0(arg2));
+    wasm._dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h3f9c898eec8f1214(arg0, arg1, isLikeNone(arg2) ? 0 : addToExternrefTable0(arg2));
 }
 
 function __wbg_adapter_46(arg0, arg1, arg2) {
-    wasm.closure10342_externref_shim(arg0, arg1, arg2);
+    wasm.closure13249_externref_shim(arg0, arg1, arg2);
 }
 
-function __wbg_adapter_49(arg0, arg1) {
-    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__ha43e1590e71609bb(arg0, arg1);
+function __wbg_adapter_55(arg0, arg1) {
+    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h022793abcc5cfb57(arg0, arg1);
 }
 
-function __wbg_adapter_58(arg0, arg1, arg2, arg3) {
-    wasm.closure10344_externref_shim(arg0, arg1, arg2, arg3);
+function __wbg_adapter_62(arg0, arg1, arg2, arg3) {
+    wasm.closure13251_externref_shim(arg0, arg1, arg2, arg3);
 }
 
 function __wbg_adapter_67(arg0, arg1) {
-    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__h2253dbe067cb55ee(arg0, arg1);
+    wasm._dyn_core__ops__function__FnMut_____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hb2fe639b3e4b0841(arg0, arg1);
 }
 
 function __wbg_adapter_70(arg0, arg1, arg2) {
-    wasm.closure114867_externref_shim(arg0, arg1, arg2);
+    wasm.closure129533_externref_shim(arg0, arg1, arg2);
 }
 
 /**
@@ -347,15 +352,15 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_Window_02fa58b243352adf = function(arg0) {
-        const ret = arg0.Window;
-        return ret;
-    };
     imports.wbg.__wbg_Window_14cc3c5ee5dce589 = function(arg0) {
         const ret = arg0.Window;
         return ret;
     };
-    imports.wbg.__wbg_WorkerGlobalScope_7b9805991ec727df = function(arg0) {
+    imports.wbg.__wbg_Window_c0db389315d58945 = function(arg0) {
+        const ret = arg0.Window;
+        return ret;
+    };
+    imports.wbg.__wbg_WorkerGlobalScope_dcb18b16374990b0 = function(arg0) {
         const ret = arg0.WorkerGlobalScope;
         return ret;
     };
@@ -1106,6 +1111,9 @@ function __wbg_get_imports() {
         const ret = arg0.getQueryParameter(arg1, arg2 >>> 0);
         return ret;
     };
+    imports.wbg.__wbg_getRandomValues_3d90134a348e46b3 = function() { return handleError(function (arg0, arg1) {
+        globalThis.crypto.getRandomValues(getArrayU8FromWasm0(arg0, arg1));
+    }, arguments) };
     imports.wbg.__wbg_getRandomValues_bcb4912f16000dc4 = function() { return handleError(function (arg0, arg1) {
         arg0.getRandomValues(arg1);
     }, arguments) };
@@ -1159,27 +1167,7 @@ function __wbg_get_imports() {
         const ret = arg0[arg1 >>> 0];
         return ret;
     };
-    imports.wbg.__wbg_height_1d93eb7f5e355d97 = function(arg0) {
-        const ret = arg0.height;
-        return ret;
-    };
     imports.wbg.__wbg_height_1f8226c8f6875110 = function(arg0) {
-        const ret = arg0.height;
-        return ret;
-    };
-    imports.wbg.__wbg_height_838cee19ba8597db = function(arg0) {
-        const ret = arg0.height;
-        return ret;
-    };
-    imports.wbg.__wbg_height_d3f39e12f0f62121 = function(arg0) {
-        const ret = arg0.height;
-        return ret;
-    };
-    imports.wbg.__wbg_height_df1aa98dfbbe11ad = function(arg0) {
-        const ret = arg0.height;
-        return ret;
-    };
-    imports.wbg.__wbg_height_e3c322f23d99ad2f = function(arg0) {
         const ret = arg0.height;
         return ret;
     };
@@ -1914,6 +1902,9 @@ function __wbg_get_imports() {
         const ret = arg0.subarray(arg1 >>> 0, arg2 >>> 0);
         return ret;
     };
+    imports.wbg.__wbg_texImage2D_57483314967bdd11 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
+        arg0.texImage2D(arg1 >>> 0, arg2, arg3, arg4, arg5, arg6, arg7 >>> 0, arg8 >>> 0, arg9);
+    }, arguments) };
     imports.wbg.__wbg_texImage2D_5f2835f02b1d1077 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9) {
         arg0.texImage2D(arg1 >>> 0, arg2, arg3, arg4, arg5, arg6, arg7 >>> 0, arg8 >>> 0, arg9);
     }, arguments) };
@@ -1921,6 +1912,9 @@ function __wbg_get_imports() {
         arg0.texImage2D(arg1 >>> 0, arg2, arg3, arg4, arg5, arg6, arg7 >>> 0, arg8 >>> 0, arg9);
     }, arguments) };
     imports.wbg.__wbg_texImage3D_921b54d09bf45af0 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) {
+        arg0.texImage3D(arg1 >>> 0, arg2, arg3, arg4, arg5, arg6, arg7, arg8 >>> 0, arg9 >>> 0, arg10);
+    }, arguments) };
+    imports.wbg.__wbg_texImage3D_a00b7a4df48cf757 = function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10) {
         arg0.texImage3D(arg1 >>> 0, arg2, arg3, arg4, arg5, arg6, arg7, arg8 >>> 0, arg9 >>> 0, arg10);
     }, arguments) };
     imports.wbg.__wbg_texParameteri_8112b26b3c360b7e = function(arg0, arg1, arg2, arg3) {
@@ -2149,14 +2143,6 @@ function __wbg_get_imports() {
     imports.wbg.__wbg_vertexAttribPointer_7a2a506cdbe3aebc = function(arg0, arg1, arg2, arg3, arg4, arg5, arg6) {
         arg0.vertexAttribPointer(arg1 >>> 0, arg2, arg3 >>> 0, arg4 !== 0, arg5, arg6);
     };
-    imports.wbg.__wbg_videoHeight_3a43327a766c1f03 = function(arg0) {
-        const ret = arg0.videoHeight;
-        return ret;
-    };
-    imports.wbg.__wbg_videoWidth_4b400cf6f4744a4d = function(arg0) {
-        const ret = arg0.videoWidth;
-        return ret;
-    };
     imports.wbg.__wbg_viewport_a1b4d71297ba89af = function(arg0, arg1, arg2, arg3, arg4) {
         arg0.viewport(arg1, arg2, arg3, arg4);
     };
@@ -2177,27 +2163,7 @@ function __wbg_get_imports() {
     imports.wbg.__wbg_webkitRequestFullscreen_416bc13a99f0f3ed = function(arg0) {
         arg0.webkitRequestFullscreen();
     };
-    imports.wbg.__wbg_width_4f334fc47ef03de1 = function(arg0) {
-        const ret = arg0.width;
-        return ret;
-    };
-    imports.wbg.__wbg_width_5dde457d606ba683 = function(arg0) {
-        const ret = arg0.width;
-        return ret;
-    };
-    imports.wbg.__wbg_width_8fe4e8f77479c2a6 = function(arg0) {
-        const ret = arg0.width;
-        return ret;
-    };
-    imports.wbg.__wbg_width_b0c1d9f437a95799 = function(arg0) {
-        const ret = arg0.width;
-        return ret;
-    };
     imports.wbg.__wbg_width_cdaf02311c1621d1 = function(arg0) {
-        const ret = arg0.width;
-        return ret;
-    };
-    imports.wbg.__wbg_width_f54c7178d3c78f16 = function(arg0) {
         const ret = arg0.width;
         return ret;
     };
@@ -2223,64 +2189,64 @@ function __wbg_get_imports() {
         const ret = false;
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15766 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_43);
+    imports.wbg.__wbindgen_closure_wrapper104384 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 72229, __wbg_adapter_67);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15768 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper188146 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 129534, __wbg_adapter_70);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15771 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_49);
+    imports.wbg.__wbindgen_closure_wrapper19879 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_43);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15773 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19881 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15775 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19883 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15782 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19885 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15786 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_58);
+    imports.wbg.__wbindgen_closure_wrapper19888 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15791 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19892 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_55);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15793 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19901 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper15800 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 10341, __wbg_adapter_46);
+    imports.wbg.__wbindgen_closure_wrapper19907 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper163493 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 114868, __wbg_adapter_70);
+    imports.wbg.__wbindgen_closure_wrapper19911 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_62);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper7074 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 4438, __wbg_adapter_36);
+    imports.wbg.__wbindgen_closure_wrapper19914 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper7076 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 4438, __wbg_adapter_36);
+    imports.wbg.__wbindgen_closure_wrapper7478 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 5123, __wbg_adapter_36);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper7078 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 4438, __wbg_adapter_36);
+    imports.wbg.__wbindgen_closure_wrapper7480 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 5123, __wbg_adapter_36);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper92507 = function(arg0, arg1, arg2) {
-        const ret = makeMutClosure(arg0, arg1, 66171, __wbg_adapter_67);
+    imports.wbg.__wbindgen_closure_wrapper7482 = function(arg0, arg1, arg2) {
+        const ret = makeMutClosure(arg0, arg1, 5123, __wbg_adapter_36);
         return ret;
     };
     imports.wbg.__wbindgen_debug_string = function(arg0, arg1) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,9 +46,138 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
 
     <!-- this is the base url relative to which other urls will be constructed. trunk will insert this from the public-url option -->
     <base href="./" />
-<link rel="modulepreload" href="./bevy-example.js" crossorigin="anonymous" integrity="sha384-RUKkGg9LUAWOzJHg032CpEhLPtZ9MN5qcUmD8gdJ1rrLUgweptFBqgmtYvvd2OTI"><link rel="preload" href="./bevy-example_bg.wasm" crossorigin="anonymous" integrity="sha384-JyVcTsHVn3SvTwWavtDfGLRoD0c/mj1kDtVSpkRq5damBgCEqxIVa4/nt0YOq580" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="./bevy-example.js" crossorigin="anonymous" integrity="sha384-Hm6eM9nT60g35ekLj3JAIk2lWp6i69/sh/J7O17VO4B740APG5a1eHZUSzs6dUJt"><link rel="preload" href="./bevy-example_bg.wasm" crossorigin="anonymous" integrity="sha384-E8u8o+4n6Evt0BQ1D+AjnhYF4DhbugA7ik82idSVTza1H+g0+Ieh5BKSL4OPZiAZ" as="fetch" type="application/wasm"></head>
 
 <body oncontextmenu="return false;">
-</body>
+<script>"use strict";
+
+(function () {
+
+    const address = '{{__TRUNK_ADDRESS__}}';
+    const base = '{{__TRUNK_WS_BASE__}}';
+    let protocol = '';
+    protocol =
+        protocol
+            ? protocol
+            : window.location.protocol === 'https:'
+                ? 'wss'
+                : 'ws';
+    const url = protocol + '://' + address + base + '.well-known/trunk/ws';
+
+    class Overlay {
+        constructor() {
+            // create an overlay
+            this._overlay = document.createElement("div");
+            const style = this._overlay.style;
+            style.height = "100vh";
+            style.width = "100vw";
+            style.position = "fixed";
+            style.top = "0";
+            style.left = "0";
+            style.backgroundColor = "rgba(222, 222, 222, 0.5)";
+            style.fontFamily = "sans-serif";
+            // not sure that's the right approach
+            style.zIndex = "1000000";
+            style.backdropFilter = "blur(1rem)";
+
+            const container = document.createElement("div");
+            // center it
+            container.style.position = "absolute";
+            container.style.top = "30%";
+            container.style.left = "15%";
+            container.style.maxWidth = "85%";
+
+            this._title = document.createElement("div");
+            this._title.innerText = "Build failure";
+            this._title.style.paddingBottom = "2rem";
+            this._title.style.fontSize = "2.5rem";
+
+            this._message = document.createElement("div");
+            this._message.style.whiteSpace = "pre-wrap";
+
+            const icon= document.createElement("div");
+            icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="#dc3545" viewBox="0 0 16 16"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg>';
+            this._title.prepend(icon);
+
+            container.append(this._title, this._message);
+            this._overlay.append(container);
+
+            this._inject();
+            window.setInterval(() => {
+                this._inject();
+            }, 250);
+        }
+
+        set reason(reason) {
+            this._message.textContent = reason;
+        }
+
+        _inject() {
+            if (!this._overlay.isConnected) {
+                // prepend it
+                document.body?.prepend(this._overlay);
+            }
+        }
+
+    }
+
+    class Client {
+        constructor(url) {
+            this.url = url;
+            this.poll_interval = 5000;
+            this._overlay = null;
+        }
+
+        start() {
+            const ws = new WebSocket(this.url);
+            ws.onmessage = (ev) => {
+                const msg = JSON.parse(ev.data);
+                switch (msg.type) {
+                    case "reload":
+                        this.reload();
+                        break;
+                    case "buildFailure":
+                        this.buildFailure(msg.data)
+                        break;
+                }
+            };
+            ws.onclose = () => this.onclose();
+        }
+
+        onclose() {
+            window.setTimeout(
+                () => {
+                    // when we successfully reconnect, we'll force a
+                    // reload (since we presumably lost connection to
+                    // trunk due to it being killed, so it will have
+                    // rebuilt on restart)
+                    const ws = new WebSocket(this.url);
+                    ws.onopen = () => window.location.reload();
+                    ws.onclose = () => this.onclose();
+                },
+                this.poll_interval);
+        }
+
+        reload() {
+            window.location.reload();
+        }
+
+        buildFailure({reason}) {
+            // also log the console
+            console.error("Build failed:", reason);
+
+            console.debug("Overlay", this._overlay);
+
+            if (!this._overlay) {
+                this._overlay = new Overlay();
+            }
+            this._overlay.reason = reason;
+        }
+    }
+
+    new Client(url).start();
+
+})()
+</script></body>
 
 </html>

--- a/examples/bevy/Cargo.toml
+++ b/examples/bevy/Cargo.toml
@@ -13,9 +13,8 @@ publish = false
 transform-gizmo-bevy.workspace = true
 
 bevy.workspace = true
-# bevy_infinite_grid = "0.14"
-# When bevy_mod_outline is updated to 0.10. Replace this with that. This rev is to use update with jump_flood unwrap panic fix.
-# bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline.git", rev = "3bd8357c656f6100c3fe13a2d6bab50f6de72a6f" }
+bevy_infinite_grid = "0.15"
+bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline.git", rev = "3cf356f58ca1bf30f26456cf854336f9851e6fe4" }
 
 [dependencies.bevy_egui]
 version = "0.34"

--- a/examples/bevy/Cargo.toml
+++ b/examples/bevy/Cargo.toml
@@ -13,12 +13,12 @@ publish = false
 transform-gizmo-bevy.workspace = true
 
 bevy.workspace = true
-bevy_infinite_grid = "0.14"
+# bevy_infinite_grid = "0.14"
 # When bevy_mod_outline is updated to 0.10. Replace this with that. This rev is to use update with jump_flood unwrap panic fix.
-bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline.git", rev = "3bd8357c656f6100c3fe13a2d6bab50f6de72a6f" }
+# bevy_mod_outline = { git = "https://github.com/komadori/bevy_mod_outline.git", rev = "3bd8357c656f6100c3fe13a2d6bab50f6de72a6f" }
 
 [dependencies.bevy_egui]
-version = "0.33"
+version = "0.34"
 features = ["open_url", "default_fonts", "render"]
 default-features = false
 

--- a/examples/bevy/src/camera.rs
+++ b/examples/bevy/src/camera.rs
@@ -33,8 +33,8 @@ fn update_camera(
     mut ev_scroll: EventReader<MouseWheel>,
     input_mouse: Res<ButtonInput<MouseButton>>,
     mut query: Query<(&mut PanOrbitCamera, &mut Transform, &Projection)>,
-) {
-    let window = window_q.single();
+) -> Result {
+    let window = window_q.single()?;
     // change input mapping for orbit and panning here
     let orbit_button = MouseButton::Right;
     let pan_button = MouseButton::Middle;
@@ -118,4 +118,6 @@ fn update_camera(
     }
 
     ev_motion.clear();
+
+    Ok(())
 }

--- a/examples/bevy/src/gui.rs
+++ b/examples/bevy/src/gui.rs
@@ -9,7 +9,10 @@ pub struct GuiPlugin;
 
 impl Plugin for GuiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(EguiPlugin).add_systems(Update, update_ui);
+        app.add_plugins(EguiPlugin {
+            enable_multipass_for_primary_context: false,
+        })
+        .add_systems(Update, update_ui);
     }
 }
 

--- a/examples/bevy/src/main.rs
+++ b/examples/bevy/src/main.rs
@@ -5,6 +5,7 @@ use picking::GizmoPickingPlugin;
 use scene::ScenePlugin;
 use transform_gizmo_bevy::GizmoHotkeys;
 
+use crate::grid::GridPlugin;
 use transform_gizmo_bevy::prelude::*;
 
 mod camera;
@@ -23,6 +24,7 @@ fn main() {
             }),
             ..default()
         }))
+        .add_plugins(GridPlugin)
         .add_plugins(GuiPlugin)
         .add_plugins(PanOrbitCameraPlugin)
         .add_plugins(ScenePlugin)

--- a/examples/bevy/src/picking.rs
+++ b/examples/bevy/src/picking.rs
@@ -73,7 +73,7 @@ pub fn manage_selection(
     if !mouse.just_released(MouseButton::Left) {
         return;
     };
-    let pointer = match pointers.get_single() {
+    let pointer = match pointers.single() {
         Ok(pointer) => pointer,
         Err(err) => match err {
             bevy::ecs::query::QuerySingleError::NoEntities(_) => {


### PR DESCRIPTION
This PR cherry-picks changes from:
- https://github.com/urholaukkarinen/transform-gizmo/pull/90
- https://github.com/urholaukkarinen/transform-gizmo/pull/88

Additionally:
- Bevy demo is updated to use newer bevy_mod_outline and bevy_infinite_grid.
- Bevy demo was missing the infinite grid plugin, so that is restored
- Web demo is been updated