### PR TITLE
Fixed gizmo visibility not updating correctly when not hovered

### DIFF
--- a/crates/transform-gizmo/src/subgizmo.rs
+++ b/crates/transform-gizmo/src/subgizmo.rs
@@ -88,9 +88,6 @@ pub(crate) struct SubGizmoConfig<T: SubGizmoKind> {
     pub(crate) focused: bool,
     /// Whether this subgizmo is active this frame
     pub(crate) active: bool,
-    /// Opacity of the subgizmo for this frame.
-    /// A fully invisible subgizmo cannot be interacted with.
-    pub(crate) opacity: f32,
     /// Implementation-specific state of the subgizmo.
     pub(crate) state: T::State,
 }
@@ -119,7 +116,6 @@ where
             config,
             focused: false,
             active: false,
-            opacity: 0.0,
             state: Default::default(),
         }
     }

--- a/crates/transform-gizmo/src/subgizmo/scale.rs
+++ b/crates/transform-gizmo/src/subgizmo/scale.rs
@@ -56,8 +56,6 @@ impl SubGizmoKind for Scale {
 
         let start_delta = distance_from_origin_2d(subgizmo, ray.screen_pos)?;
 
-        subgizmo.opacity = pick_result.visibility as _;
-
         subgizmo.state.start_delta = start_delta;
 
         if pick_result.picked {
@@ -95,7 +93,6 @@ impl SubGizmoKind for Scale {
         match (subgizmo.transform_kind, subgizmo.direction) {
             (TransformKind::Axis, _) => draw_arrow(
                 &subgizmo.config,
-                subgizmo.opacity,
                 subgizmo.focused,
                 subgizmo.direction,
                 subgizmo.mode,
@@ -106,12 +103,9 @@ impl SubGizmoKind for Scale {
                 outer_circle_radius(&subgizmo.config),
                 false,
             ),
-            (TransformKind::Plane, _) => draw_plane(
-                &subgizmo.config,
-                subgizmo.opacity,
-                subgizmo.focused,
-                subgizmo.direction,
-            ),
+            (TransformKind::Plane, _) => {
+                draw_plane(&subgizmo.config, subgizmo.focused, subgizmo.direction)
+            }
         }
     }
 }

--- a/crates/transform-gizmo/src/subgizmo/translation.rs
+++ b/crates/transform-gizmo/src/subgizmo/translation.rs
@@ -52,8 +52,6 @@ impl SubGizmoKind for Translation {
     fn pick(subgizmo: &mut TranslationSubGizmo, ray: Ray) -> Option<f64> {
         let pick_result = Self::pick_preview(subgizmo, ray);
 
-        subgizmo.opacity = pick_result.visibility as _;
-
         subgizmo.state.start_view_dir = subgizmo.config.view_forward();
         subgizmo.state.start_point = pick_result.subgizmo_point;
         subgizmo.state.last_point = pick_result.subgizmo_point;
@@ -118,7 +116,6 @@ impl SubGizmoKind for Translation {
         match (subgizmo.transform_kind, subgizmo.direction) {
             (TransformKind::Axis, _) => draw_arrow(
                 &subgizmo.config,
-                subgizmo.opacity,
                 subgizmo.focused,
                 subgizmo.direction,
                 subgizmo.mode,
@@ -129,12 +126,9 @@ impl SubGizmoKind for Translation {
                 inner_circle_radius(&subgizmo.config),
                 false,
             ),
-            (TransformKind::Plane, _) => draw_plane(
-                &subgizmo.config,
-                subgizmo.opacity,
-                subgizmo.focused,
-                subgizmo.direction,
-            ),
+            (TransformKind::Plane, _) => {
+                draw_plane(&subgizmo.config, subgizmo.focused, subgizmo.direction)
+            }
         }
     }
 }

--- a/docs/bevy-example.js
+++ b/docs/bevy-example.js
@@ -2189,51 +2189,51 @@ function __wbg_get_imports() {
         const ret = false;
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper104384 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper104385 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 72229, __wbg_adapter_67);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper188146 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper188147 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 129534, __wbg_adapter_70);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19879 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19880 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_43);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19881 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19882 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19883 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19884 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19885 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19886 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19888 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19889 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19892 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19893 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_55);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19901 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19902 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19907 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19908 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19911 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19912 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_62);
         return ret;
     };
-    imports.wbg.__wbindgen_closure_wrapper19914 = function(arg0, arg1, arg2) {
+    imports.wbg.__wbindgen_closure_wrapper19915 = function(arg0, arg1, arg2) {
         const ret = makeMutClosure(arg0, arg1, 13248, __wbg_adapter_46);
         return ret;
     };

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
 
     <!-- this is the base url relative to which other urls will be constructed. trunk will insert this from the public-url option -->
     <base href="./" />
-<link rel="modulepreload" href="./bevy-example.js" crossorigin="anonymous" integrity="sha384-Hm6eM9nT60g35ekLj3JAIk2lWp6i69/sh/J7O17VO4B740APG5a1eHZUSzs6dUJt"><link rel="preload" href="./bevy-example_bg.wasm" crossorigin="anonymous" integrity="sha384-E8u8o+4n6Evt0BQ1D+AjnhYF4DhbugA7ik82idSVTza1H+g0+Ieh5BKSL4OPZiAZ" as="fetch" type="application/wasm"></head>
+<link rel="modulepreload" href="./bevy-example.js" crossorigin="anonymous" integrity="sha384-gXTn9r0CNxgcA0t6u/eB5rJO9Mr40ZxS/Ku/8mu1uqZLpE2+rh5OWwFJv9ZBWqVa"><link rel="preload" href="./bevy-example_bg.wasm" crossorigin="anonymous" integrity="sha384-eeggS5cbYBl0R1g7uETq2+M7/yLDRgf3cpAWNDYPsKtxPPdDNF5SMEw7WTsNIuDx" as="fetch" type="application/wasm"></head>
 
 <body oncontextmenu="return false;">
 <script>"use strict";


### PR DESCRIPTION
Some subgizmos were not initially visibled until you hovered the gizmo. Also, if you toggled some of the modes in the GizmoOptions, the some subgizmos would disappear and only appear once hovered again.

The subgizmo opacity/visibility calculation is now done both in picking and drawing phase and not stored in the gizmo state.