### PR TITLE
Fix left_handed detection for reverse-Z orthographic projections

### DIFF
--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -150,7 +150,7 @@ impl PreparedGizmoConfig {
         let view_projection = projection_matrix * view_matrix;
 
         let left_handed = if projection_matrix.z_axis.w == 0.0 {
-            // Orthographic: a positive Z scale normally indicates left-handed coords,
+            // A positive Z scale normally indicates left-handed coords,
             // but some engines (e.g. Bevy) swap near/far for reverse-Z depth, which
             // also flips the Z scale sign while remaining right-handed.
             // Disambiguate by checking the view matrix's actual handedness.

--- a/crates/transform-gizmo/src/config.rs
+++ b/crates/transform-gizmo/src/config.rs
@@ -150,7 +150,18 @@ impl PreparedGizmoConfig {
         let view_projection = projection_matrix * view_matrix;
 
         let left_handed = if projection_matrix.z_axis.w == 0.0 {
-            projection_matrix.z_axis.z > 0.0
+            // Orthographic: a positive Z scale normally indicates left-handed coords,
+            // but some engines (e.g. Bevy) swap near/far for reverse-Z depth, which
+            // also flips the Z scale sign while remaining right-handed.
+            // Disambiguate by checking the view matrix's actual handedness.
+            if projection_matrix.z_axis.z > 0.0 {
+                let vx = view_matrix.x_axis.xyz();
+                let vy = view_matrix.y_axis.xyz();
+                let vz = view_matrix.z_axis.xyz();
+                vx.cross(vy).dot(vz) < 0.0
+            } else {
+                false
+            }
         } else {
             projection_matrix.z_axis.w > 0.0
         };


### PR DESCRIPTION
Bevy swaps near/far in the orthographic projection matrix, producing a positive Z scale that the existing detection incorrectly interprets as a left-handed coordinate system. This causes gizmo rotation arcs to face away from the camera.

When the orthographic Z scale is positive (ambiguous case), we should check the view matrix's actual handedness via cross product to disambiguate between true left-handed coords and reverse-Z right-handed coords.