### PR TITLE
Update to egui 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ transform-gizmo = { version = "0.9.0", path = "crates/transform-gizmo" }
 transform-gizmo-egui = { version = "0.9.0", path = "crates/transform-gizmo-egui" }
 transform-gizmo-bevy = { version = "0.9.0", path = "crates/transform-gizmo-bevy" }
 
-egui = "0.34"
-eframe = "0.34"
-emath = "0.34"
-epaint = "0.34"
-ecolor = "0.34"
+egui = "0.35"
+eframe = "0.35"
+emath = "0.35"
+epaint = "0.35"
+ecolor = "0.35"
 glam = { version = "0.32", features = ["mint"] }
 mint = "0.5"
 enum_dispatch = "0.3"

--- a/examples/egui/src/main.rs
+++ b/examples/egui/src/main.rs
@@ -150,11 +150,11 @@ impl ExampleApp {
 
 impl eframe::App for ExampleApp {
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        egui::Panel::left("options_panel").show_inside(ui, |ui| {
+        egui::Panel::left("options_panel").show(ui, |ui| {
             self.draw_options(ui);
         });
 
-        egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             self.draw_gizmo(ui);
         });
     }


### PR DESCRIPTION
Bumps the `egui` stack (`egui`, `eframe`, `emath`, `epaint`, `ecolor`) from 0.34 to 0.35.

No source changes were required inside the crate itself. The `transform-gizmo-egui` compiles cleanly, `egui-example` needed a minor change. `egui 0.35` raises the MSRV to `1.92`, which already matches this workspace's `rust-version`.

`egui 0.35` has no released successor for downstream crates pinned to `0.34`, so this unblocks integrators moving to the latest `egui`.